### PR TITLE
feat: added configuration object field

### DIFF
--- a/public/ace-themes/sql_console.js
+++ b/public/ace-themes/sql_console.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as ace from 'brace';
+
+ace.define('ace/theme/sql_console', ['require', 'exports', 'module', 'ace/lib/dom'], function (
+  acequire,
+  exports,
+  module
+) {
+  exports.isDark = false;
+  exports.cssClass = 'ace-sql-console';
+  exports.cssText = require('../index.scss');
+
+  const dom = acequire('../lib/dom');
+  dom.importCssString(exports.cssText, exports.cssClass);
+});

--- a/public/components/register_model/__tests__/register_model.test.tsx
+++ b/public/components/register_model/__tests__/register_model.test.tsx
@@ -17,6 +17,7 @@ describe('<RegisterModel />', () => {
       name: /register model/i,
     });
     const modelFileInput = screen.getByLabelText<HTMLInputElement>(/model file/i);
+    const configurationInput = screen.getByLabelText(/configuration object/i);
     const form = screen.getByTestId('mlCommonsPlugin-registerModelForm');
     const user = userEvent.setup();
 
@@ -35,6 +36,7 @@ describe('<RegisterModel />', () => {
       versionInput,
       descriptionInput,
       annotationsInput,
+      configurationInput,
       submitButton,
       modelFileInput,
       form,
@@ -112,4 +114,7 @@ describe('<RegisterModel />', () => {
     expect(urlInput).toBeInvalid();
     expect(onSubmitMock).not.toHaveBeenCalled();
   });
+
+  // TODO: add tests for Configuration object field.
+  // (Having difficulties to test EuiCodeEditor with testing-library)
 });

--- a/public/components/register_model/model_configuration.tsx
+++ b/public/components/register_model/model_configuration.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import {
+  EuiFormRow,
+  EuiPanel,
+  EuiTitle,
+  EuiHorizontalRule,
+  EuiCodeEditor,
+  EuiText,
+  EuiButtonEmpty,
+  EuiFlyout,
+  EuiFlyoutHeader,
+  EuiFlyoutBody,
+} from '@elastic/eui';
+import { useController } from 'react-hook-form';
+import type { Control } from 'react-hook-form';
+
+import '../../ace-themes/sql_console.js';
+import { FORM_ITEM_WIDTH } from './form_constants';
+import type { ModelFileFormData, ModelUrlFormData } from './register_model.types';
+
+function validateConfigurationObject(value: string) {
+  try {
+    JSON.parse(value.trim());
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+export const ConfigurationPanel = (props: {
+  formControl: Control<ModelFileFormData | ModelUrlFormData>;
+}) => {
+  const [isHelpVisible, setIsHelpVisible] = useState(false);
+  const configurationFieldController = useController({
+    name: 'configuration',
+    control: props.formControl,
+    rules: { required: true, validate: validateConfigurationObject },
+  });
+
+  return (
+    <EuiPanel>
+      <EuiTitle size="s">
+        <h3>Configuration</h3>
+      </EuiTitle>
+      <EuiHorizontalRule margin="m" />
+      <EuiFormRow
+        style={{ maxWidth: FORM_ITEM_WIDTH * 2 }}
+        label="Configuration object"
+        isInvalid={Boolean(configurationFieldController.fieldState.error)}
+        labelAppend={
+          <EuiText size="xs">
+            <EuiButtonEmpty onClick={() => setIsHelpVisible(true)} size="xs" color="primary">
+              Help
+            </EuiButtonEmpty>
+          </EuiText>
+        }
+      >
+        <EuiCodeEditor
+          tabSize={2}
+          theme="sql_console"
+          width="100%"
+          showPrintMargin={false}
+          height="10rem"
+          mode="json"
+          value={configurationFieldController.field.value}
+          onChange={(value) => configurationFieldController.field.onChange(value)}
+          setOptions={{
+            fontSize: '14px',
+            enableBasicAutocompletion: true,
+            enableLiveAutocompletion: true,
+          }}
+        />
+      </EuiFormRow>
+      {isHelpVisible && (
+        <EuiFlyout ownFocus onClose={() => setIsHelpVisible(false)}>
+          <EuiFlyoutHeader hasBorder>
+            <EuiTitle size="m">
+              <h2 id="flyoutTitle">Help</h2>
+            </EuiTitle>
+          </EuiFlyoutHeader>
+          <EuiFlyoutBody>
+            <EuiText>
+              <p>TODO</p>
+            </EuiText>
+          </EuiFlyoutBody>
+        </EuiFlyout>
+      )}
+    </EuiPanel>
+  );
+};

--- a/public/components/register_model/register_model.tsx
+++ b/public/components/register_model/register_model.tsx
@@ -5,6 +5,7 @@ import { EuiPageHeader, EuiSpacer, EuiForm, EuiButton } from '@elastic/eui';
 import { ModelDetailsPanel } from './model_details';
 import type { ModelFileFormData, ModelUrlFormData } from './register_model.types';
 import { ArtifactPanel } from './artifact';
+import { ConfigurationPanel } from './model_configuration';
 
 interface RegisterModelFormProps {
   onSubmit?: (data: ModelFileFormData | ModelUrlFormData) => void;
@@ -14,6 +15,7 @@ export const RegisterModelForm = (props: RegisterModelFormProps) => {
   const { handleSubmit, control } = useForm<ModelFileFormData | ModelUrlFormData>({
     defaultValues: {
       version: 1,
+      configuration: '{}',
     },
   });
 
@@ -41,6 +43,8 @@ export const RegisterModelForm = (props: RegisterModelFormProps) => {
       <ModelDetailsPanel formControl={control} />
       <EuiSpacer />
       <ArtifactPanel formControl={control} />
+      <EuiSpacer />
+      <ConfigurationPanel formControl={control} />
       <EuiSpacer />
       <EuiButton type="submit" fill>
         Register model

--- a/public/components/register_model/register_model.types.ts
+++ b/public/components/register_model/register_model.types.ts
@@ -3,6 +3,7 @@ interface ModelFormBase {
   version: number;
   description: string;
   annotations: string;
+  configuration: string;
 }
 
 /**

--- a/public/index.scss
+++ b/public/index.scss
@@ -4,3 +4,180 @@
  */
 
 /* stylelint-disable no-empty-source */
+.ace-sql-console {
+  .ace_gutter {
+    background: rgb(237, 239, 243);
+    color: rgb(0, 0, 0);
+  }
+
+  .ace_print-margin {
+    width: 1px;
+    background: #e8e8e8;
+  }
+
+  .ace_fold {
+    background-color: #6b72e6;
+  }
+
+  background-color: rgb(245, 247, 250);
+  color: black;
+
+  .ace_marker-layer {
+    .ace_active-line.ace_active-line {
+      background-color: rgb(211, 218, 230);
+    }
+
+    .ace_selection {
+      background: rgb(181, 213, 255);
+    }
+
+    .ace_step {
+      background: rgb(252, 255, 0);
+    }
+
+    .ace_stack {
+      background: rgb(164, 229, 101);
+    }
+
+    .ace_bracket {
+      margin: -1px 0 0 -1px;
+      border: 1px solid rgb(192, 192, 192);
+    }
+
+    .ace_active-line {
+      background: rgba(0, 0, 0, 0.07);
+    }
+
+    .ace_selected-word {
+      background: rgb(250, 250, 255);
+      border: 1px solid rgb(200, 200, 250);
+    }
+  }
+
+  .ace_cursor {
+    color: black;
+  }
+
+  .ace_invisible {
+    color: rgb(191, 191, 191);
+  }
+
+  .ace_storage {
+    color: rgb(157, 106, 242);
+  }
+
+  .ace_keyword {
+    color: rgb(157, 106, 242);
+  }
+
+  .ace_constant {
+    color: rgb(197, 6, 11);
+  }
+
+  .ace_constant.ace_buildin {
+    color: rgb(88, 72, 246);
+  }
+
+  .ace_constant.ace_language {
+    color: rgb(88, 92, 246);
+  }
+
+  .ace_constant.ace_library {
+    color: rgb(6, 150, 14);
+  }
+
+  .ace_invalid {
+    background-color: rgba(255, 0, 0, 0.1);
+    color: red;
+  }
+
+  .ace_support.ace_function {
+    color: rgb(60, 76, 114);
+  }
+
+  .ace_support.ace_constant {
+    color: rgb(6, 150, 14);
+  }
+
+  .ace_support.ace_type {
+    color: rgb(109, 121, 222);
+  }
+
+  .ace_support.ace_class {
+    color: rgb(109, 121, 222);
+  }
+
+  .ace_keyword.ace_operator {
+    color: rgb(104, 118, 135);
+  }
+
+  .ace_string {
+    color: rgb(3, 106, 7);
+  }
+
+  .ace_comment {
+    color: rgb(76, 136, 107);
+  }
+
+  .ace_comment.ace_doc {
+    color: rgb(0, 102, 255);
+  }
+
+  .ace_comment.ace_doc.ace_tag {
+    color: rgb(128, 159, 191);
+  }
+
+  .ace_constant.ace_numeric {
+    color: rgb(0, 0, 205);
+  }
+
+  .ace_variable {
+    color: rgb(49, 132, 149);
+  }
+
+  .ace_xml-pe {
+    color: rgb(104, 104, 91);
+  }
+
+  .ace_entity.ace_name.ace_function {
+    color: #0000a2;
+  }
+
+  .ace_heading {
+    color: rgb(12, 7, 255);
+  }
+
+  .ace_list {
+    color: rgb(185, 6, 144);
+  }
+
+  .ace_meta.ace_tag {
+    color: rgb(0, 22, 142);
+  }
+
+  .ace_string.ace_regex {
+    color: rgb(255, 0, 0);
+  }
+
+  .ace_gutter-active-line {
+    background-color: rgb(211, 218, 230);
+  }
+
+  .ace_indent-guide {
+    background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAE0lEQVQImWP4////f4bLly//BwAmVgd1/w11/gAAAABJRU5ErkJggg==')
+      right repeat-y;
+  }
+}
+
+.ace-sql-console.ace_multiselect {
+  .ace_selection.ace_start {
+    box-shadow: 0 0 3px 0px white;
+  }
+}
+
+.ace_editor {
+  .ace-sql-console {
+    height: 200px;
+  }
+}
+


### PR DESCRIPTION
This is a section on Register Model form that allows user to type a JSON configuration object for their ML model.

There are a couple of TODOs of this PR:
1. We will need tests for `configuration object field` on `register model` form, but it's challenge to test `EuiCodeEditor` with `testing-library`, since `EuiCodeEditor` is also deprecated, I will left the test for future improvements.
2. The `configuration object` `FlyOut` panel is empty at the moment, will need to update once the content is confirmed

Signed-off-by: Yulong Ruan <ruanyl@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
