### PR TITLE
bring in-app navigation bar back

### DIFF
--- a/common/router.ts
+++ b/common/router.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ModelList } from '../public/components/model_list';
 import { Monitoring } from '../public/components/monitoring';
+import { RegisterModelForm } from '../public/components/register_model';
 import { routerPaths } from './router_paths';
 
 interface RouteConfig {
@@ -18,6 +20,16 @@ export const ROUTES: RouteConfig[] = [
     path: routerPaths.monitoring,
     Component: Monitoring,
     label: 'Monitoring',
+  },
+  {
+    path: routerPaths.registerModel,
+    label: 'Register Model',
+    Component: RegisterModelForm,
+  },
+  {
+    path: routerPaths.modelList,
+    label: 'Model List',
+    Component: ModelList,
   },
 ];
 

--- a/common/router_paths.ts
+++ b/common/router_paths.ts
@@ -7,4 +7,5 @@ export const routerPaths = {
   root: '/',
   monitoring: '/monitoring',
   registerModel: '/model-registry/register-model',
+  modelList: '/model-registry/model-list',
 };

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { I18nProvider } from '@osd/i18n/react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { Redirect, Route, Switch } from 'react-router-dom';
-import { EuiPage, EuiPageBody } from '@elastic/eui';
+import { EuiPage, EuiPageBody, EuiPageSideBar } from '@elastic/eui';
 import { ROUTES } from '../../common/router';
 import { routerPaths } from '../../common/router_paths';
 
@@ -18,6 +18,7 @@ import { NavigationPublicPluginStart } from '../../../../src/plugins/navigation/
 import { DataPublicPluginStart } from '../../../../src/plugins/data/public';
 
 import { GlobalBreadcrumbs } from './global_breadcrumbs';
+import { NavPanel } from './nav_panel';
 
 interface MlCommonsPluginAppDeps {
   basename: string;
@@ -48,14 +49,12 @@ export const MlCommonsPluginApp = ({
     <ReduxProvider store={store}>
       <I18nProvider>
         <>
-          <Switch>
-            <EuiPage>
-              {/*
-              <EuiPageSideBar>
-                <NavPanel />
-              </EuiPageSideBar>
-              */}
-              <EuiPageBody component="main">
+          <EuiPage>
+            <EuiPageSideBar>
+              <NavPanel />
+            </EuiPageSideBar>
+            <EuiPageBody component="main">
+              <Switch>
                 {ROUTES.map(({ path, Component, exact }) => (
                   <Route
                     key={path}
@@ -67,9 +66,9 @@ export const MlCommonsPluginApp = ({
                   />
                 ))}
                 <Redirect from={routerPaths.root} to={routerPaths.monitoring} />
-              </EuiPageBody>
-            </EuiPage>
-          </Switch>
+              </Switch>
+            </EuiPageBody>
+          </EuiPage>
           <GlobalBreadcrumbs chrome={chrome} basename={basename} />
         </>
       </I18nProvider>


### PR DESCRIPTION
1. bring in-app navigation bar back
2. fix an issue that a refresh always redirect user to monitoring page

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
