### PR TITLE
feat: add enabled flag to plugin config

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PluginInitializerContext } from '../../../src/core/server';
+import { schema } from '@osd/config-schema';
+
+import { PluginConfigDescriptor, PluginInitializerContext } from '../../../src/core/server';
 import { MlCommonsPlugin } from './plugin';
 
 // This exports static code and TypeScript types,
@@ -14,3 +16,9 @@ export function plugin(initializerContext: PluginInitializerContext) {
 }
 
 export { MlCommonsPluginSetup, MlCommonsPluginStart } from './types';
+
+export const config: PluginConfigDescriptor = {
+  schema: schema.object({
+    enabled: schema.boolean({ defaultValue: false }),
+  }),
+};


### PR DESCRIPTION
### Description
Add enabled flag to plugin config to control plugin enabled in OSD.
To enable this plugin, add config to `config/opensearch_dashboards.yml`
```yml
ml_commons_dashboards.enabled: false
```


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
