### PR TITLE
feat: disallow user to type if text exceed max length

### DIFF
--- a/public/components/register_model/__tests__/register_model_details.test.tsx
+++ b/public/components/register_model/__tests__/register_model_details.test.tsx
@@ -50,19 +50,12 @@ describe('<RegisterModel /> Details', () => {
     expect(onSubmitMock).not.toHaveBeenCalled();
   });
 
-  it('should NOT submit the register model form if model name length exceeded 80', async () => {
+  it('should NOT allow to input a model name which exceed max length: 80', async () => {
     const result = await setup();
 
     await result.user.clear(result.nameInput);
-    await result.user.type(result.nameInput, 'x'.repeat(80));
-    expect(result.nameInput).toBeValid();
-
-    await result.user.clear(result.nameInput);
     await result.user.type(result.nameInput, 'x'.repeat(81));
-    expect(result.nameInput).toBeInvalid();
-
-    await result.user.click(result.submitButton);
-    expect(onSubmitMock).not.toHaveBeenCalled();
+    expect(result.nameInput.value).toHaveLength(80);
   });
 
   it('should NOT submit the register model form if model name is duplicated', async () => {
@@ -90,18 +83,11 @@ describe('<RegisterModel /> Details', () => {
     expect(onSubmitMock).not.toHaveBeenCalled();
   });
 
-  it('should NOT submit the register model form if model description length exceed 200', async () => {
+  it('should NOT allow to input a model description which exceed max length: 200', async () => {
     const result = await setup();
 
     await result.user.clear(result.descriptionInput);
-    await result.user.type(result.descriptionInput, 'x'.repeat(200));
-    expect(result.descriptionInput).toBeValid();
-
-    await result.user.clear(result.descriptionInput);
     await result.user.type(result.descriptionInput, 'x'.repeat(201));
-    expect(result.descriptionInput).toBeInvalid();
-
-    await result.user.click(result.submitButton);
-    expect(onSubmitMock).not.toHaveBeenCalled();
+    expect(result.descriptionInput.value).toHaveLength(200);
   });
 });

--- a/public/components/register_model/__tests__/register_model_version_notes.test.tsx
+++ b/public/components/register_model/__tests__/register_model_version_notes.test.tsx
@@ -36,18 +36,11 @@ describe('<RegisterModel /> Version notes', () => {
     expect(onSubmitMock).toHaveBeenCalled();
   });
 
-  it('should NOT submit the register model form if model version notes length exceed 200', async () => {
+  it('should NOT allow to input a model note which exceed max length: 200', async () => {
     const result = await setup();
 
     await result.user.clear(result.versionNotesInput);
-    await result.user.type(result.versionNotesInput, 'x'.repeat(200));
-    expect(result.versionNotesInput).toBeValid();
-
-    await result.user.clear(result.versionNotesInput);
     await result.user.type(result.versionNotesInput, 'x'.repeat(201));
-    expect(result.versionNotesInput).toBeInvalid();
-
-    await result.user.click(result.submitButton);
-    expect(onSubmitMock).not.toHaveBeenCalled();
+    expect(result.versionNotesInput.value).toHaveLength(200);
   });
 });

--- a/public/components/register_model/model_details.tsx
+++ b/public/components/register_model/model_details.tsx
@@ -80,6 +80,7 @@ export const ModelDetailsPanel = () => {
         <EuiFieldText
           inputRef={nameInputRef}
           isInvalid={Boolean(nameFieldController.fieldState.error)}
+          maxLength={NAME_MAX_LENGTH}
           {...nameField}
           onFocus={handleModelNameFocus}
           onBlur={handleModelNameBlur}
@@ -97,6 +98,7 @@ export const ModelDetailsPanel = () => {
         <EuiTextArea
           inputRef={descriptionInputRef}
           isInvalid={Boolean(descriptionFieldController.fieldState.error)}
+          maxLength={DESCRIPTION_MAX_LENGTH}
           {...descriptionField}
         />
       </EuiFormRow>

--- a/public/components/register_model/model_details.tsx
+++ b/public/components/register_model/model_details.tsx
@@ -69,7 +69,8 @@ export const ModelDetailsPanel = () => {
         error={nameFieldController.fieldState.error?.message}
         helpText={
           <EuiText color="subdued" size="xs">
-            {Math.max(NAME_MAX_LENGTH - nameField.value.length, 0)} characters allowed.
+            {Math.max(NAME_MAX_LENGTH - nameField.value.length, 0)} characters{' '}
+            {nameField.value.length ? 'left' : 'allowed'}.
             <br />
             Use a unique for the model.
           </EuiText>
@@ -91,7 +92,7 @@ export const ModelDetailsPanel = () => {
         helpText={`${Math.max(
           DESCRIPTION_MAX_LENGTH - descriptionField.value.length,
           0
-        )} characters allowed.`}
+        )} characters ${descriptionField.value.length ? 'left' : 'allowed'}.`}
       >
         <EuiTextArea
           inputRef={descriptionInputRef}

--- a/public/components/register_model/model_details.tsx
+++ b/public/components/register_model/model_details.tsx
@@ -12,7 +12,7 @@ import { APIProvider } from '../../apis/api_provider';
 const NAME_MAX_LENGTH = 80;
 const DESCRIPTION_MAX_LENGTH = 200;
 
-const isUniqueModelName = async (name: string) => {
+const isDuplicateModelName = async (name: string) => {
   const searchResult = await APIProvider.getAPI('model').search({
     name,
     from: 0,
@@ -30,11 +30,10 @@ export const ModelDetailsPanel = () => {
     rules: {
       required: { value: true, message: 'Name can not be empty' },
       validate: async (name) => {
-        return !modelNameFocusedRef.current && !!name && (await isUniqueModelName(name))
+        return !modelNameFocusedRef.current && !!name && (await isDuplicateModelName(name))
           ? 'This name is already in use. Use a unique name for the model.'
           : undefined;
       },
-      maxLength: { value: NAME_MAX_LENGTH, message: 'Text exceed max length' },
     },
   });
 
@@ -43,7 +42,6 @@ export const ModelDetailsPanel = () => {
     control,
     rules: {
       required: { value: true, message: 'Description can not be empty' },
-      maxLength: { value: DESCRIPTION_MAX_LENGTH, message: 'Text exceed max length' },
     },
   });
 

--- a/public/components/register_model/model_version_notes.tsx
+++ b/public/components/register_model/model_version_notes.tsx
@@ -32,7 +32,7 @@ export const ModelVersionNotesPanel = () => {
         helpText={`${Math.max(
           VERSION_NOTES_MAX_LENGTH - (versionNotesField.value?.length ?? 0),
           0
-        )} characters allowed.`}
+        )} characters ${versionNotesField.value?.length ? 'left' : 'allowed'}.`}
         isInvalid={Boolean(fieldController.fieldState.error)}
         error={fieldController.fieldState.error?.message}
         label="Notes"

--- a/public/components/register_model/model_version_notes.tsx
+++ b/public/components/register_model/model_version_notes.tsx
@@ -41,6 +41,7 @@ export const ModelVersionNotesPanel = () => {
         <EuiTextArea
           inputRef={ref}
           isInvalid={Boolean(fieldController.fieldState.error)}
+          maxLength={VERSION_NOTES_MAX_LENGTH}
           style={{ height: 80 }}
           {...versionNotesField}
         />

--- a/public/components/register_model/model_version_notes.tsx
+++ b/public/components/register_model/model_version_notes.tsx
@@ -17,7 +17,6 @@ export const ModelVersionNotesPanel = () => {
   const fieldController = useController({
     name: 'versionNotes',
     control,
-    rules: { maxLength: { value: VERSION_NOTES_MAX_LENGTH, message: 'Text exceed max length' } },
   });
   const { ref, ...versionNotesField } = fieldController.field;
 


### PR DESCRIPTION
The restriction is applied to:
1. Model name input
2. Model description input
3. Model note input

+ The react-hook-form validation rules on these inputs are removed
+ Renamed `isUniqueModelName` to `isDuplicateModelName`

Signed-off-by: Yulong Ruan <ruanyl@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
