### PR TITLE
feat: add model file format select

### DIFF
--- a/public/components/register_model/__tests__/register_model_artifact.test.tsx
+++ b/public/components/register_model/__tests__/register_model_artifact.test.tsx
@@ -83,13 +83,13 @@ describe('<RegisterModel /> Artifact', () => {
     // Empty model file selection by clicking the `Remove` button on EuiFilePicker
     await result.user.click(screen.getByLabelText(/clear selected files/i));
 
-    const modelFileInput = screen.getByLabelText<HTMLInputElement>(/file/i);
+    const modelFileInput = screen.getByLabelText<HTMLInputElement>(/^file$/i);
     // User select a file with maximum accepted size
     const validFile = new File(['test model file'], 'model.zip', { type: 'application/zip' });
     Object.defineProperty(validFile, 'size', { value: 4 * ONE_GB });
     await result.user.upload(modelFileInput, validFile);
 
-    expect(screen.getByLabelText(/file/i, { selector: 'input[type="file"]' })).toBeValid();
+    expect(screen.getByLabelText(/^file$/i, { selector: 'input[type="file"]' })).toBeValid();
     await result.user.click(result.submitButton);
     expect(onSubmitWithFileMock).toHaveBeenCalled();
   });
@@ -100,7 +100,7 @@ describe('<RegisterModel /> Artifact', () => {
     // Empty model file selection by clicking the `Remove` button on EuiFilePicker
     await result.user.click(screen.getByLabelText(/clear selected files/i));
 
-    const modelFileInput = screen.getByLabelText<HTMLInputElement>(/file/i);
+    const modelFileInput = screen.getByLabelText<HTMLInputElement>(/^file$/i);
     // File size can not exceed 4GB
     const invalidFile = new File(['test model file'], 'model.zip', { type: 'application/zip' });
     Object.defineProperty(invalidFile, 'size', { value: 4 * ONE_GB + 1 });
@@ -117,7 +117,7 @@ describe('<RegisterModel /> Artifact', () => {
     // Empty model file selection by clicking the `Remove` button on EuiFilePicker
     await result.user.click(screen.getByLabelText(/clear selected files/i));
 
-    const modelFileInput = screen.getByLabelText<HTMLInputElement>(/file/i);
+    const modelFileInput = screen.getByLabelText<HTMLInputElement>(/^file$/i);
     // Only ZIP(.zip) file is allowed
     const invalidFile = new File(['test model file'], 'model.json', { type: 'application/json' });
     await result.user.upload(modelFileInput, invalidFile);

--- a/public/components/register_model/__tests__/register_model_file_format.test.tsx
+++ b/public/components/register_model/__tests__/register_model_file_format.test.tsx
@@ -52,4 +52,16 @@ describe('<RegisterModel /> Artifact', () => {
     // Error callout
     expect(screen.queryByText(/Model file format: Select a model format/i)).toBeInTheDocument();
   });
+
+  it('should submit the form with selected model file format', async () => {
+    const result = await setup();
+    const fileFormatInput = screen.getByLabelText(/^Model file format$/i);
+    await result.user.click(fileFormatInput);
+    await result.user.click(screen.getByText('Torchscript(.pt)'));
+
+    await result.user.click(result.submitButton);
+    expect(onSubmitWithFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({ modelFileFormat: 'TORCH_SCRIPT' })
+    );
+  });
 });

--- a/public/components/register_model/__tests__/register_model_file_format.test.tsx
+++ b/public/components/register_model/__tests__/register_model_file_format.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { screen } from '../../../../test/test_utils';
+import { setup } from './setup';
+import * as formHooks from '../register_model.hooks';
+import { ModelFileUploadManager } from '../model_file_upload_manager';
+import * as formAPI from '../register_model_api';
+
+jest.mock('../../../apis/model_repository');
+
+describe('<RegisterModel /> Artifact', () => {
+  const onSubmitWithFileMock = jest.fn().mockResolvedValue('model_id');
+  const onSubmitWithURLMock = jest.fn();
+  const uploadMock = jest.fn();
+
+  beforeEach(() => {
+    jest
+      .spyOn(formHooks, 'useModelTags')
+      .mockReturnValue([false, { keys: ['Key1', 'Key2'], values: ['Value1', 'Value2'] }]);
+    jest.spyOn(formAPI, 'submitModelWithFile').mockImplementation(onSubmitWithFileMock);
+    jest.spyOn(formAPI, 'submitModelWithURL').mockImplementation(onSubmitWithURLMock);
+    jest.spyOn(ModelFileUploadManager.prototype, 'upload').mockImplementation(uploadMock);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not submit the form if model format is not selected', async () => {
+    const result = await setup();
+    result.user.click(screen.getByLabelText('Clear input'));
+
+    await result.user.click(result.submitButton);
+    expect(onSubmitWithFileMock).not.toHaveBeenCalled();
+  });
+
+  it('should display error messages if model format is not selected', async () => {
+    const result = await setup();
+    result.user.click(screen.getByLabelText('Clear input'));
+
+    await result.user.click(result.submitButton);
+    expect(onSubmitWithFileMock).not.toHaveBeenCalled();
+
+    // Field error message
+    expect(
+      screen.queryByText(/Model file format is required. Select a model file format/i)
+    ).toBeInTheDocument();
+
+    // Error callout
+    expect(screen.queryByText(/Model file format: Select a model format/i)).toBeInTheDocument();
+  });
+});

--- a/public/components/register_model/__tests__/setup.tsx
+++ b/public/components/register_model/__tests__/setup.tsx
@@ -10,7 +10,7 @@ import { UserEvent } from '@testing-library/user-event/dist/types/setup/setup';
 
 import { RegisterModelForm } from '../register_model';
 import { Model } from '../../../apis/model';
-import { render, RenderWithRouteProps, screen, waitFor } from '../../../../test/test_utils';
+import { render, RenderWithRouteProps, screen, waitFor, within } from '../../../../test/test_utils';
 import { ModelFileFormData, ModelUrlFormData } from '../register_model.types';
 
 jest.mock('../../../apis/task');
@@ -71,7 +71,8 @@ export async function setup(
   const submitButton = screen.getByRole<HTMLButtonElement>('button', {
     name: mode === 'version' ? /register version/i : /register model/i,
   });
-  const modelFileInput = screen.queryByLabelText<HTMLInputElement>(/file/i);
+  const modelFileInput = screen.queryByLabelText<HTMLInputElement>(/^file$/i);
+  const fileFormatInput = screen.queryByLabelText(/^Model file format$/i);
   const form = screen.getByTestId('mlCommonsPlugin-registerModelForm');
   const user = userEvent.setup();
   const versionNotesInput = screen.getByLabelText<HTMLTextAreaElement>(/notes/i);
@@ -82,6 +83,11 @@ export async function setup(
       modelFileInput,
       new File(['test model file'], 'model.zip', { type: 'application/zip' })
     );
+  }
+
+  if (fileFormatInput) {
+    await user.click(fileFormatInput);
+    await user.click(screen.getByText('ONNX(.onnx)'));
   }
 
   if (mode === 'version') {

--- a/public/components/register_model/constants.ts
+++ b/public/components/register_model/constants.ts
@@ -54,6 +54,11 @@ export const FORM_ERRORS = [
     message: 'Model file format: Select a model file format.',
   },
   {
+    field: 'modelFileFormat',
+    type: 'required',
+    message: 'Model file format: Select a model format.',
+  },
+  {
     field: 'configuration',
     type: 'required',
     message: 'JSON configuration: Add a JSON configuration.',

--- a/public/components/register_model/register_model.tsx
+++ b/public/components/register_model/register_model.tsx
@@ -49,6 +49,7 @@ const DEFAULT_VALUES = {
   version: '1',
   configuration: '',
   tags: [{ key: '', value: '' }],
+  modelFileFormat: '',
 };
 
 const FORM_ID = 'mlModelUploadForm';

--- a/public/components/register_model/register_model.types.ts
+++ b/public/components/register_model/register_model.types.ts
@@ -13,6 +13,7 @@ interface ModelFormBase {
   version: string;
   description: string;
   configuration: string;
+  modelFileFormat: string;
   tags?: Tag[];
   versionNotes?: string;
 }


### PR DESCRIPTION
Added a new register model form field: model file format select which allows user to select from ONNX or Torchscript

Signed-off-by: Yulong Ruan <ruanyl@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
