### PR TITLE
feat: tweaks form section titles per new design

### DIFF
--- a/public/components/register_model/artifact.tsx
+++ b/public/components/register_model/artifact.tsx
@@ -5,7 +5,6 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 import {
-  EuiTitle,
   htmlIdGenerator,
   EuiSpacer,
   EuiText,
@@ -69,12 +68,9 @@ export const ArtifactPanel = () => {
 
   return (
     <div>
-      <EuiTitle size="s">
-        <h2>File and version information</h2>
-      </EuiTitle>
-      <EuiTitle size="s">
+      <EuiText size="s">
         <h3>Artifact</h3>
-      </EuiTitle>
+      </EuiText>
       <EuiText style={{ maxWidth: 725 }}>
         <small>
           The zipped artifact must include a model file and a tokenizer file. If uploading with a

--- a/public/components/register_model/model_configuration.tsx
+++ b/public/components/register_model/model_configuration.tsx
@@ -6,7 +6,6 @@
 import React, { useState } from 'react';
 import {
   EuiFormRow,
-  EuiTitle,
   EuiCodeEditor,
   EuiText,
   EuiTextColor,
@@ -101,9 +100,9 @@ export const ConfigurationPanel = () => {
 
   return (
     <div data-test-subj="ml-registerModelConfiguration">
-      <EuiTitle size="s">
+      <EuiText size="s">
         <h3>Configuration</h3>
-      </EuiTitle>
+      </EuiText>
       <EuiText style={{ maxWidth: 725 }}>
         <small>
           The model configuration specifies the{' '}

--- a/public/components/register_model/model_details.tsx
+++ b/public/components/register_model/model_details.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useCallback, useRef } from 'react';
-import { EuiFieldText, EuiFormRow, EuiTitle, EuiTextArea, EuiText } from '@elastic/eui';
+import { EuiFieldText, EuiFormRow, EuiTextArea, EuiText } from '@elastic/eui';
 import { useController, useFormContext } from 'react-hook-form';
 import { ModelFileFormData, ModelUrlFormData } from './register_model.types';
 import { APIProvider } from '../../apis/api_provider';
@@ -60,9 +60,9 @@ export const ModelDetailsPanel = () => {
 
   return (
     <div>
-      <EuiTitle size="s">
-        <h3>Model Details</h3>
-      </EuiTitle>
+      <EuiText size="s">
+        <h3>Details</h3>
+      </EuiText>
       <EuiFormRow
         label="Name"
         isInvalid={Boolean(nameFieldController.fieldState.error)}

--- a/public/components/register_model/model_tags.tsx
+++ b/public/components/register_model/model_tags.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { EuiButton, EuiTitle, EuiSpacer, EuiText, EuiLink } from '@elastic/eui';
+import { EuiButton, EuiSpacer, EuiText, EuiLink } from '@elastic/eui';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 
@@ -31,11 +31,11 @@ export const ModelTagsPanel = () => {
 
   return (
     <div>
-      <EuiTitle size="s">
+      <EuiText size="s">
         <h3>
           Tags - <i style={{ fontWeight: 300 }}>optional</i>
         </h3>
-      </EuiTitle>
+      </EuiText>
       <EuiText style={{ maxWidth: 725 }}>
         <small>
           {isRegisterNewVersion ? (

--- a/public/components/register_model/model_version_notes.tsx
+++ b/public/components/register_model/model_version_notes.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiTitle, EuiSpacer, EuiFormRow, EuiTextArea } from '@elastic/eui';
+import { EuiText, EuiSpacer, EuiFormRow, EuiTextArea } from '@elastic/eui';
 import { useFormContext, useController } from 'react-hook-form';
 
 import type { ModelFileFormData, ModelUrlFormData } from './register_model.types';
@@ -22,11 +22,11 @@ export const ModelVersionNotesPanel = () => {
 
   return (
     <div>
-      <EuiTitle size="s">
+      <EuiText size="s">
         <h3>
           Version notes - <i style={{ fontWeight: 300 }}>optional</i>
         </h3>
-      </EuiTitle>
+      </EuiText>
       <EuiSpacer size="m" />
       <EuiFormRow
         helpText={`${Math.max(

--- a/public/components/register_model/register_model.tsx
+++ b/public/components/register_model/register_model.tsx
@@ -58,6 +58,22 @@ interface RegisterModelFormProps {
   defaultValues?: Partial<ModelFileFormData> | Partial<ModelUrlFormData>;
 }
 
+const ModelOverviewTitle = () => {
+  return (
+    <EuiText size="s">
+      <h2>Model overview</h2>
+    </EuiText>
+  );
+};
+
+const FileAndVersionTitle = () => {
+  return (
+    <EuiText size="s">
+      <h2>File and version information</h2>
+    </EuiText>
+  );
+};
+
 export const RegisterModelForm = ({ defaultValues = DEFAULT_VALUES }: RegisterModelFormProps) => {
   const history = useHistory();
   const [isSubmitted, setIsSubmitted] = useState(false);
@@ -78,8 +94,10 @@ export const RegisterModelForm = ({ defaultValues = DEFAULT_VALUES }: RegisterMo
     formType === 'import'
       ? [ModelDetailsPanel, ModelTagsPanel, ModelVersionNotesPanel]
       : [
+          ...(latestVersionId ? [] : [ModelOverviewTitle]),
           ...(latestVersionId ? [] : [ModelDetailsPanel]),
           ...(latestVersionId ? [] : [ModelTagsPanel]),
+          ...(latestVersionId ? [] : [FileAndVersionTitle]),
           ArtifactPanel,
           ConfigurationPanel,
           ...(latestVersionId ? [ModelTagsPanel] : []),
@@ -294,7 +312,11 @@ export const RegisterModelForm = ({ defaultValues = DEFAULT_VALUES }: RegisterMo
           {partials.map((FormPartial, i) => (
             <React.Fragment key={i}>
               <FormPartial />
-              <EuiSpacer size="xl" />
+              {FormPartial === ModelOverviewTitle || FormPartial === FileAndVersionTitle ? (
+                <EuiSpacer size="s" />
+              ) : (
+                <EuiSpacer size="xl" />
+              )}
             </React.Fragment>
           ))}
         </EuiPanel>


### PR DESCRIPTION
The title `Model overview` and `File and version information` only present when creating new model group(NOT for registering new version and importing from OpenSearch repository)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
