### PR TITLE
fix: avoid ml nodes show not responding during loading (#145)

### DIFF
--- a/public/components/preview_panel/__tests__/preview_panel.test.tsx
+++ b/public/components/preview_panel/__tests__/preview_panel.test.tsx
@@ -89,6 +89,7 @@ describe('<PreviewPanel />', () => {
   });
 
   it('should NOT render nodes during model profile API loading', async () => {
+    jest.useFakeTimers();
     const getModelMock = jest.spyOn(APIProvider.getAPI('profile'), 'getModel').mockReturnValue(
       new Promise((resolve) => {
         setTimeout(() => {
@@ -98,7 +99,7 @@ describe('<PreviewPanel />', () => {
             worker_nodes: ['node-1'],
             not_worker_nodes: ['node-2', 'node-3'],
           });
-        }, 100);
+        }, 3000);
       })
     );
     setup({});
@@ -106,6 +107,7 @@ describe('<PreviewPanel />', () => {
     expect(screen.queryByText('node-2')).not.toBeInTheDocument();
     expect(screen.queryByText('node-3')).not.toBeInTheDocument();
 
+    jest.advanceTimersByTime(3000);
     await act(async () => {
       await getModelMock.mock.results[0].value;
     });
@@ -113,5 +115,6 @@ describe('<PreviewPanel />', () => {
     expect(await screen.getByText('node-1')).toBeInTheDocument();
     expect(await screen.getByText('node-2')).toBeInTheDocument();
     expect(await screen.getByText('node-3')).toBeInTheDocument();
+    jest.useRealTimers();
   });
 });

--- a/public/components/preview_panel/__tests__/preview_panel.test.tsx
+++ b/public/components/preview_panel/__tests__/preview_panel.test.tsx
@@ -90,7 +90,7 @@ describe('<PreviewPanel />', () => {
 
   it('should NOT render nodes during model profile API loading', async () => {
     jest.useFakeTimers();
-    const getModelMock = jest.spyOn(APIProvider.getAPI('profile'), 'getModel').mockReturnValue(
+    jest.spyOn(APIProvider.getAPI('profile'), 'getModel').mockReturnValue(
       new Promise((resolve) => {
         setTimeout(() => {
           resolve({
@@ -108,13 +108,12 @@ describe('<PreviewPanel />', () => {
     expect(screen.queryByText('node-3')).not.toBeInTheDocument();
 
     jest.advanceTimersByTime(3000);
-    await act(async () => {
-      await getModelMock.mock.results[0].value;
-    });
-
-    expect(await screen.getByText('node-1')).toBeInTheDocument();
-    expect(await screen.getByText('node-2')).toBeInTheDocument();
-    expect(await screen.getByText('node-3')).toBeInTheDocument();
     jest.useRealTimers();
+
+    waitFor(() => {
+      expect(screen.getByText('node-1')).toBeInTheDocument();
+      expect(screen.getByText('node-2')).toBeInTheDocument();
+      expect(screen.getByText('node-3')).toBeInTheDocument();
+    });
   });
 });

--- a/public/components/preview_panel/index.tsx
+++ b/public/components/preview_panel/index.tsx
@@ -42,13 +42,16 @@ export const PreviewPanel = ({ onClose, model }: Props) => {
   const { id, name } = model;
   const { data, loading } = useFetcher(APIProvider.getAPI('profile').getModel, id);
   const nodes = useMemo(() => {
+    if (loading) {
+      return [];
+    }
     const targetNodes = data?.target_worker_nodes ?? model.planningWorkerNodes ?? [];
     const deployedNodes = data?.worker_nodes ?? [];
     return targetNodes.map((item) => ({
       id: item,
       deployed: deployedNodes.indexOf(item) > -1 ? true : false,
     }));
-  }, [data, model]);
+  }, [data, model, loading]);
 
   const respondingStatus = useMemo(() => {
     if (loading) {


### PR DESCRIPTION
### Description
To fix #145 , render empty ML nodes while calling model profile API

### Issues Resolved
#145 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
