### PR TITLE
fix: update model status labels according to the API change in 2.7

### DIFF
--- a/common/model.ts
+++ b/common/model.ts
@@ -3,15 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// TODO: rename the enum keys accordingly
 export enum MODEL_STATE {
-  loaded = 'LOADED',
+  loaded = 'DEPLOYED',
   trained = 'TRAINED',
-  unloaded = 'UNLOADED',
-  uploaded = 'UPLOADED',
-  uploading = 'UPLOADING',
-  loading = 'LOADING',
-  partiallyLoaded = 'PARTIALLY_LOADED',
-  loadFailed = 'LOAD_FAILED',
+  unloaded = 'UNDEPLOYED',
+  uploaded = 'REGISTERED',
+  uploading = 'REGISTERING',
+  loading = 'DEPLOYING',
+  partiallyLoaded = 'PARTIALLY_DEPLOYED',
+  loadFailed = 'DEPLOY_FAILED',
 }
 
 export interface OpenSearchModelBase {

--- a/public/components/monitoring/tests/use_monitoring.test.ts
+++ b/public/components/monitoring/tests/use_monitoring.test.ts
@@ -51,7 +51,7 @@ describe('useMonitoring', () => {
       expect(Model.prototype.search).toHaveBeenCalledWith(
         expect.objectContaining({
           nameOrId: 'foo',
-          states: ['LOAD_FAILED', 'LOADED', 'PARTIALLY_LOADED'],
+          states: ['DEPLOY_FAILED', 'DEPLOYED', 'PARTIALLY_DEPLOYED'],
         })
       )
     );
@@ -63,7 +63,7 @@ describe('useMonitoring', () => {
       expect(Model.prototype.search).toHaveBeenCalledWith(
         expect.objectContaining({
           nameOrId: 'foo',
-          states: ['LOADED'],
+          states: ['DEPLOYED'],
         })
       )
     );
@@ -78,7 +78,7 @@ describe('useMonitoring', () => {
     await waitFor(() =>
       expect(Model.prototype.search).toHaveBeenCalledWith(
         expect.objectContaining({
-          states: ['PARTIALLY_LOADED'],
+          states: ['PARTIALLY_DEPLOYED'],
         })
       )
     );
@@ -137,7 +137,7 @@ describe('useMonitoring.pageStatus', () => {
               id: 'model-1-id',
               name: 'model-1-name',
               algorithm: 'TEXT_EMBEDDING',
-              model_state: 'LOADED',
+              model_state: 'DEPLOYED',
               model_version: '1.0.0',
               current_worker_node_count: 1,
               planning_worker_node_count: 3,


### PR DESCRIPTION
This PR updates the model status labels according to the ml-commons breaking changes introduced in 2.7: https://github.com/opensearch-project/ml-commons/pull/822

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
