### PR TITLE
feat: support for adding tag types

### DIFF
--- a/public/components/register_model/__tests__/error_call_out.test.tsx
+++ b/public/components/register_model/__tests__/error_call_out.test.tsx
@@ -5,7 +5,6 @@
 
 import { screen } from '../../../../test/test_utils';
 import { setup } from './setup';
-import * as formHooks from '../register_model.hooks';
 import * as formAPI from '../register_model_api';
 import { ModelFileUploadManager } from '../model_file_upload_manager';
 
@@ -15,9 +14,6 @@ describe('<RegisterModel /> ErrorCallOut', () => {
   const uploadMock = jest.fn();
 
   beforeEach(() => {
-    jest
-      .spyOn(formHooks, 'useModelTags')
-      .mockReturnValue([false, { keys: ['Key1', 'Key2'], values: ['Value1', 'Value2'] }]);
     jest.spyOn(formAPI, 'submitModelWithFile').mockImplementation(onSubmitWithFileMock);
     jest.spyOn(formAPI, 'submitModelWithURL').mockImplementation(onSubmitWithURLMock);
     jest.spyOn(ModelFileUploadManager.prototype, 'upload').mockImplementation(uploadMock);

--- a/public/components/register_model/__tests__/register_model_artifact.test.tsx
+++ b/public/components/register_model/__tests__/register_model_artifact.test.tsx
@@ -5,7 +5,6 @@
 
 import { screen } from '../../../../test/test_utils';
 import { setup } from './setup';
-import * as formHooks from '../register_model.hooks';
 import { ModelFileUploadManager } from '../model_file_upload_manager';
 import * as formAPI from '../register_model_api';
 import { ONE_GB } from '../../../../common/constant';
@@ -16,9 +15,6 @@ describe('<RegisterModel /> Artifact', () => {
   const uploadMock = jest.fn();
 
   beforeEach(() => {
-    jest
-      .spyOn(formHooks, 'useModelTags')
-      .mockReturnValue([false, { keys: ['Key1', 'Key2'], values: ['Value1', 'Value2'] }]);
     jest.spyOn(formAPI, 'submitModelWithFile').mockImplementation(onSubmitWithFileMock);
     jest.spyOn(formAPI, 'submitModelWithURL').mockImplementation(onSubmitWithURLMock);
     jest.spyOn(ModelFileUploadManager.prototype, 'upload').mockImplementation(uploadMock);

--- a/public/components/register_model/__tests__/register_model_configuration.test.tsx
+++ b/public/components/register_model/__tests__/register_model_configuration.test.tsx
@@ -6,7 +6,6 @@
 import { screen, within } from '../../../../test/test_utils';
 import { setup } from './setup';
 import * as formAPI from '../register_model_api';
-import * as formHooks from '../register_model.hooks';
 import { ModelFileUploadManager } from '../model_file_upload_manager';
 
 describe('<RegisterModel /> Configuration', () => {
@@ -15,9 +14,6 @@ describe('<RegisterModel /> Configuration', () => {
   const uploadMock = jest.fn();
 
   beforeEach(() => {
-    jest
-      .spyOn(formHooks, 'useModelTags')
-      .mockReturnValue([false, { keys: ['Key1', 'Key2'], values: ['Value1', 'Value2'] }]);
     jest.spyOn(formAPI, 'submitModelWithFile').mockImplementation(onSubmitWithFileMock);
     jest.spyOn(formAPI, 'submitModelWithURL').mockImplementation(onSubmitWithURLMock);
     jest.spyOn(ModelFileUploadManager.prototype, 'upload').mockImplementation(uploadMock);

--- a/public/components/register_model/__tests__/register_model_details.test.tsx
+++ b/public/components/register_model/__tests__/register_model_details.test.tsx
@@ -4,7 +4,6 @@
  */
 
 import { setup } from './setup';
-import * as formHooks from '../register_model.hooks';
 import * as formAPI from '../register_model_api';
 import { Model } from '../../../apis/model';
 
@@ -12,9 +11,6 @@ describe('<RegisterModel /> Details', () => {
   const onSubmitMock = jest.fn().mockResolvedValue('model_id');
 
   beforeEach(() => {
-    jest
-      .spyOn(formHooks, 'useModelTags')
-      .mockReturnValue([false, { keys: ['Key1', 'Key2'], values: ['Value1', 'Value2'] }]);
     jest.spyOn(formAPI, 'submitModelWithFile').mockImplementation(onSubmitMock);
   });
 

--- a/public/components/register_model/__tests__/register_model_file_format.test.tsx
+++ b/public/components/register_model/__tests__/register_model_file_format.test.tsx
@@ -5,7 +5,6 @@
 
 import { screen } from '../../../../test/test_utils';
 import { setup } from './setup';
-import * as formHooks from '../register_model.hooks';
 import { ModelFileUploadManager } from '../model_file_upload_manager';
 import * as formAPI from '../register_model_api';
 
@@ -15,9 +14,6 @@ describe('<RegisterModel /> Artifact', () => {
   const uploadMock = jest.fn();
 
   beforeEach(() => {
-    jest
-      .spyOn(formHooks, 'useModelTags')
-      .mockReturnValue([false, { keys: ['Key1', 'Key2'], values: ['Value1', 'Value2'] }]);
     jest.spyOn(formAPI, 'submitModelWithFile').mockImplementation(onSubmitWithFileMock);
     jest.spyOn(formAPI, 'submitModelWithURL').mockImplementation(onSubmitWithURLMock);
     jest.spyOn(ModelFileUploadManager.prototype, 'upload').mockImplementation(uploadMock);

--- a/public/components/register_model/__tests__/register_model_tags.test.tsx
+++ b/public/components/register_model/__tests__/register_model_tags.test.tsx
@@ -54,7 +54,7 @@ describe('<RegisterModel /> Tags', () => {
     await result.user.click(result.submitButton);
 
     expect(onSubmitMock).toHaveBeenCalledWith(
-      expect.objectContaining({ tags: [{ key: 'Key1', value: 'Value1' }] })
+      expect.objectContaining({ tags: [{ key: 'Key1', value: 'Value1', type: 'string' }] })
     );
   });
 
@@ -74,9 +74,9 @@ describe('<RegisterModel /> Tags', () => {
     expect(onSubmitMock).toHaveBeenCalledWith(
       expect.objectContaining({
         tags: [
-          { key: '', value: '' },
-          { key: '', value: '' },
-          { key: '', value: '' },
+          { key: '', value: '', type: 'string' },
+          { key: '', value: '', type: 'string' },
+          { key: '', value: '', type: 'string' },
         ],
       })
     );
@@ -199,7 +199,7 @@ describe('<RegisterModel /> Tags', () => {
 
     expect(onSubmitMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        tags: [{ key: '', value: '' }],
+        tags: [{ key: '', value: '', type: 'string' }],
       })
     );
   });

--- a/public/components/register_model/__tests__/register_model_version_notes.test.tsx
+++ b/public/components/register_model/__tests__/register_model_version_notes.test.tsx
@@ -4,16 +4,12 @@
  */
 
 import { setup } from './setup';
-import * as formHooks from '../register_model.hooks';
 import * as formAPI from '../register_model_api';
 
 describe('<RegisterModel /> Version notes', () => {
   const onSubmitMock = jest.fn().mockResolvedValue('model_id');
 
   beforeEach(() => {
-    jest
-      .spyOn(formHooks, 'useModelTags')
-      .mockReturnValue([false, { keys: ['Key1', 'Key2'], values: ['Value1', 'Value2'] }]);
     jest.spyOn(formAPI, 'submitModelWithFile').mockImplementation(onSubmitMock);
   });
 

--- a/public/components/register_model/__tests__/setup.tsx
+++ b/public/components/register_model/__tests__/setup.tsx
@@ -10,7 +10,7 @@ import { UserEvent } from '@testing-library/user-event/dist/types/setup/setup';
 
 import { RegisterModelForm } from '../register_model';
 import { Model } from '../../../apis/model';
-import { render, RenderWithRouteProps, screen, waitFor, within } from '../../../../test/test_utils';
+import { render, RenderWithRouteProps, screen, waitFor } from '../../../../test/test_utils';
 import { ModelFileFormData, ModelUrlFormData } from '../register_model.types';
 
 jest.mock('../../../apis/task');
@@ -40,7 +40,7 @@ const DEFAULT_VALUES = {
   description: '',
   version: '1',
   configuration: CONFIGURATION,
-  tags: [{ key: '', value: '' }],
+  tags: [{ key: '', value: '', type: 'string' as const }],
 };
 
 export async function setup(options: {

--- a/public/components/register_model/__tests__/tag_type_popover.test.tsx
+++ b/public/components/register_model/__tests__/tag_type_popover.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+
+import { render, screen } from '../../../../test/test_utils';
+import { TagTypePopover } from '../tag_type_popover';
+
+describe('<TagTypePopover />', () => {
+  it('should display tag type popover when clicking', async () => {
+    const user = userEvent.setup();
+
+    render(<TagTypePopover value="string" onApply={jest.fn()} />);
+    expect(screen.queryByText('String')).toBeInTheDocument();
+
+    // click button to show the popover
+    await user.click(screen.getByText('String'));
+
+    expect(screen.getByLabelText('String')).toBeChecked();
+    expect(screen.getByLabelText('Number')).not.toBeChecked();
+    expect(screen.queryByText('Apply')).toBeInTheDocument();
+  });
+
+  it('should call onApply', async () => {
+    const user = userEvent.setup();
+    const onApplyMock = jest.fn();
+
+    render(<TagTypePopover value="string" onApply={onApplyMock} />);
+    expect(screen.queryByText('String')).toBeInTheDocument();
+
+    // click button to show the popover
+    await user.click(screen.getByText('String'));
+
+    // select Number
+    await user.click(screen.getByLabelText('Number'));
+    await user.click(screen.getByText('Apply'));
+
+    expect(onApplyMock).toHaveBeenCalledWith('number');
+  });
+});

--- a/public/components/register_model/model_tags.tsx
+++ b/public/components/register_model/model_tags.tsx
@@ -26,7 +26,7 @@ export const ModelTagsPanel = () => {
   const maxTagNum = isRegisterNewVersion ? keys.length : MAX_TAG_NUM;
 
   const addNewTag = useCallback(() => {
-    append({ key: '', value: '' });
+    append({ key: '', value: '', type: 'string' });
   }, [append]);
 
   return (

--- a/public/components/register_model/model_tags.tsx
+++ b/public/components/register_model/model_tags.tsx
@@ -17,13 +17,13 @@ const MAX_TAG_NUM = 10;
 export const ModelTagsPanel = () => {
   const { control } = useFormContext<ModelFileFormData | ModelUrlFormData>();
   const { id: latestVersionId } = useParams<{ id: string | undefined }>();
-  const [, { keys, values }] = useModelTags();
+  const [, tags] = useModelTags();
   const { fields, append, remove } = useFieldArray({
     name: 'tags',
     control,
   });
   const isRegisterNewVersion = !!latestVersionId;
-  const maxTagNum = isRegisterNewVersion ? keys.length : MAX_TAG_NUM;
+  const maxTagNum = isRegisterNewVersion ? tags.length : MAX_TAG_NUM;
 
   const addNewTag = useCallback(() => {
     append({ key: '', value: '', type: 'string' });
@@ -62,8 +62,7 @@ export const ModelTagsPanel = () => {
           <ModelTagField
             key={field.id}
             index={index}
-            tagKeys={keys}
-            tagValues={values}
+            tagGroups={tags}
             onDelete={remove}
             allowKeyCreate={!latestVersionId}
           />

--- a/public/components/register_model/register_model.hooks.ts
+++ b/public/components/register_model/register_model.hooks.ts
@@ -8,6 +8,39 @@ import { useEffect, useState } from 'react';
 const keys = ['tag1', 'tag2'];
 const values = ['value1', 'value2'];
 
+const results = [
+  {
+    name: 'Accuracy: test',
+    type: 'number' as const,
+    values: [0.9, 0.8, 0.75],
+  },
+  {
+    name: 'Accuracy: training',
+    type: 'number' as const,
+    values: [0.9, 0.8, 0.75],
+  },
+  {
+    name: 'Accuracy: validation',
+    type: 'number' as const,
+    values: [0.9, 0.8, 0.75],
+  },
+  {
+    name: 'Task',
+    type: 'string' as const,
+    values: [
+      'Computer vision',
+      'Image classification',
+      'Image-to-image',
+      'Natural language processing',
+    ],
+  },
+  {
+    name: 'Team',
+    type: 'string' as const,
+    values: ['IT', 'Finance', 'HR'],
+  },
+];
+
 /**
  * TODO: implement this function so that it retrieve tags from BE
  */
@@ -24,5 +57,5 @@ export const useModelTags = () => {
     };
   }, []);
 
-  return [loading, { keys, values }] as const;
+  return [loading, results] as const;
 };

--- a/public/components/register_model/register_model.tsx
+++ b/public/components/register_model/register_model.tsx
@@ -49,7 +49,7 @@ const DEFAULT_VALUES = {
   description: '',
   version: '1',
   configuration: '',
-  tags: [{ key: '', value: '' }],
+  tags: [{ key: '', value: '', type: 'string' as const }],
   modelFileFormat: '',
 };
 

--- a/public/components/register_model/register_model.types.ts
+++ b/public/components/register_model/register_model.types.ts
@@ -6,6 +6,7 @@
 export interface Tag {
   key: string;
   value: string;
+  type: 'number' | 'string';
 }
 
 interface ModelFormBase {

--- a/public/components/register_model/tag_field.tsx
+++ b/public/components/register_model/tag_field.tsx
@@ -16,7 +16,7 @@ import {
   EuiToken,
   EuiToolTip,
 } from '@elastic/eui';
-import React, { useEffect, useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { useController, useWatch, useFormContext } from 'react-hook-form';
 import { FORM_ITEM_WIDTH } from './form_constants';
 import { ModelFileFormData, ModelUrlFormData } from './register_model.types';
@@ -132,17 +132,18 @@ export const ModelTagField = ({
     control,
   });
 
-  useEffect(() => {
-    if (selectedTagGroup && tagTypeController.field.value !== selectedTagGroup.type) {
-      tagTypeController.field.onChange(selectedTagGroup.type);
-    }
-  }, [selectedTagGroup, tagTypeController.field]);
-
   const onKeyChange = useCallback(
     (data: Array<EuiComboBoxOptionOption<TagGroup>>) => {
-      tagKeyController.field.onChange(getComboBoxValue(data));
+      const tagKey = getComboBoxValue(data);
+      tagKeyController.field.onChange(tagKey);
+
+      // update tag type if selected an existed tag
+      const tagGroup = tagGroups.find((t) => t.name === tagKey);
+      if (tagGroup) {
+        tagTypeController.field.onChange(tagGroup.type);
+      }
     },
-    [tagKeyController.field]
+    [tagKeyController.field, tagTypeController.field, tagGroups]
   );
 
   const onStringValueChange = useCallback(

--- a/public/components/register_model/tag_field.tsx
+++ b/public/components/register_model/tag_field.tsx
@@ -4,15 +4,21 @@
  */
 
 import {
-  EuiButton,
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
   EuiContext,
+  EuiButtonIcon,
+  EuiPopover,
+  EuiButtonEmpty,
+  EuiPopoverTitle,
+  EuiPopoverFooter,
+  EuiButton,
+  EuiRadio,
 } from '@elastic/eui';
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useController, useWatch, useFormContext } from 'react-hook-form';
 import { FORM_ITEM_WIDTH } from './form_constants';
 import { ModelFileFormData, ModelUrlFormData } from './register_model.types';
@@ -54,6 +60,7 @@ export const ModelTagField = ({
   allowKeyCreate,
   onDelete,
 }: ModelTagFieldProps) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const rowEleRef = useRef<HTMLDivElement>(null);
   const { trigger, control } = useFormContext<ModelFileFormData | ModelUrlFormData>();
   const tags = useWatch({
@@ -173,7 +180,7 @@ export const ModelTagField = ({
   );
 
   return (
-    <EuiFlexGroup ref={rowEleRef} tabIndex={-1} onBlur={onBlur}>
+    <EuiFlexGroup gutterSize="m" ref={rowEleRef} tabIndex={-1} onBlur={onBlur}>
       <EuiFlexItem grow={false} style={{ width: FORM_ITEM_WIDTH }}>
         <EuiContext i18n={KEY_COMBOBOX_I18N}>
           <EuiFormRow
@@ -208,6 +215,33 @@ export const ModelTagField = ({
             error={tagValueController.fieldState.error?.message}
           >
             <EuiComboBox
+              prepend={
+                <EuiPopover
+                  button={
+                    <EuiButtonEmpty
+                      onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+                      size="xs"
+                      iconType="arrowDown"
+                      iconSide="right"
+                    >
+                      String
+                    </EuiButtonEmpty>
+                  }
+                  closePopover={() => setIsPopoverOpen(false)}
+                  isOpen={isPopoverOpen}
+                  panelPaddingSize="s"
+                  panelStyle={{ minWidth: 140 }}
+                >
+                  <EuiPopoverTitle>TAG TYPE</EuiPopoverTitle>
+                  <EuiRadio label="String" id="" onChange={() => {}} />
+                  <EuiRadio label="Number" id="" onChange={() => {}} />
+                  <EuiPopoverFooter>
+                    <EuiButton fullWidth size="s">
+                      Apply
+                    </EuiButton>
+                  </EuiPopoverFooter>
+                </EuiPopover>
+              }
               placeholder="Select or add a value"
               isInvalid={Boolean(tagValueController.fieldState.error)}
               singleSelection={{ asPlainText: true }}
@@ -225,9 +259,13 @@ export const ModelTagField = ({
         </EuiContext>
       </EuiFlexItem>
       <EuiFlexItem grow={false} style={index === 0 ? { transform: 'translateY(22px)' } : undefined}>
-        <EuiButton aria-label={`Remove tag at row ${index + 1}`} onClick={() => onDelete(index)}>
-          Remove
-        </EuiButton>
+        <EuiButtonIcon
+          display="base"
+          size="m"
+          iconType="cross"
+          aria-label={`Remove tag at row ${index + 1}`}
+          onClick={() => onDelete(index)}
+        />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/components/register_model/tag_field.tsx
+++ b/public/components/register_model/tag_field.tsx
@@ -133,7 +133,7 @@ export const ModelTagField = ({
   });
 
   useEffect(() => {
-    if (selectedTagGroup) {
+    if (selectedTagGroup && tagTypeController.field.value !== selectedTagGroup.type) {
       tagTypeController.field.onChange(selectedTagGroup.type);
     }
   }, [selectedTagGroup, tagTypeController.field]);

--- a/public/components/register_model/tag_type_popover.tsx
+++ b/public/components/register_model/tag_type_popover.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useCallback } from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiPopover,
+  EuiPopoverFooter,
+  EuiPopoverTitle,
+  EuiRadio,
+  htmlIdGenerator,
+} from '@elastic/eui';
+
+type TagValueType = 'number' | 'string';
+
+interface TagTypePopoverProps {
+  value: TagValueType;
+  onApply: (type: TagValueType) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+export const TagTypePopover = ({ value, onApply, disabled, className }: TagTypePopoverProps) => {
+  const [tagType, setTagType] = useState(value);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  const onApplyType = useCallback(() => {
+    onApply(tagType);
+    setIsPopoverOpen(false);
+  }, [tagType, onApply]);
+
+  return (
+    <EuiPopover
+      className={className}
+      button={
+        <EuiButtonEmpty
+          aria-label="select tag type"
+          style={{ width: 95 }}
+          onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+          size="xs"
+          iconType="arrowDown"
+          iconSide="right"
+          disabled={disabled}
+        >
+          {value === 'number' ? 'Number' : 'String'}
+        </EuiButtonEmpty>
+      }
+      closePopover={() => setIsPopoverOpen(false)}
+      isOpen={isPopoverOpen}
+      panelPaddingSize="s"
+    >
+      <EuiPopoverTitle>TAG TYPE</EuiPopoverTitle>
+      <EuiRadio
+        label="String"
+        id={htmlIdGenerator()()}
+        value="string"
+        checked={tagType === 'string'}
+        onChange={() => setTagType('string')}
+      />
+      <EuiRadio
+        label="Number"
+        id={htmlIdGenerator()()}
+        value="number"
+        checked={tagType === 'number'}
+        onChange={() => setTagType('number')}
+      />
+      <EuiPopoverFooter>
+        <EuiButton fullWidth size="s" onClick={onApplyType}>
+          Apply
+        </EuiButton>
+      </EuiPopoverFooter>
+    </EuiPopover>
+  );
+};


### PR DESCRIPTION
Add tag type to model tag field component, user can select tag type from `number` or `string`

Signed-off-by: Yulong Ruan <ruanyl@amazon.com>### Description


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
