### PR TITLE
Feature/add details tab content in model group page

### DIFF
--- a/public/components/common/forms/__tests__/error_call_out.test.tsx
+++ b/public/components/common/forms/__tests__/error_call_out.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import React from 'react';
+import { screen, render } from '../../../../../test/test_utils';
+
+import { ErrorCallOut } from '../error_call_out';
+
+describe('<ErrorCallOut />', () => {
+  it('should NOT render call out if errors is empty', () => {
+    render(<ErrorCallOut errorMessages={[]} formErrors={{}} />);
+
+    expect(screen.queryByLabelText('Address errors in the form')).toBeNull();
+  });
+
+  it('should render error call out if errors is not empty', () => {
+    render(
+      <ErrorCallOut
+        errorMessages={[
+          {
+            field: 'name',
+            type: 'required',
+            message: 'Name: Enter a name.',
+          },
+          {
+            field: 'name',
+            type: 'duplicateNames',
+            message: 'Name: Use a unique name.',
+          },
+          {
+            field: 'modelFile',
+            type: 'required',
+            message: 'File: Add a file.',
+          },
+        ]}
+        formErrors={{
+          name: {
+            type: 'multi',
+            types: {
+              required: 'name required',
+              duplicateNames: 'name duplicate',
+            },
+          },
+          modelFile: {
+            type: 'required',
+            message: 'Model file is required',
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByLabelText('Address errors in the form')).toBeInTheDocument();
+    expect(screen.getByText(/Name: Enter a name./)).toBeInTheDocument();
+    expect(screen.getByText(/Name: Use a unique name./)).toBeInTheDocument();
+    expect(screen.getByText(/File: Add a file./)).toBeInTheDocument();
+  });
+});

--- a/public/components/common/forms/__tests__/model_description_field.test.tsx
+++ b/public/components/common/forms/__tests__/model_description_field.test.tsx
@@ -11,14 +11,14 @@ import { render, screen } from '../../../../../test/test_utils';
 
 import { ModelDescriptionField } from '../model_description_field';
 
-const setup = (description: string = '') => {
+const setup = (description: string = '', readOnly = false) => {
   const DescriptionForm = () => {
     const { control } = useForm({
       defaultValues: {
         description,
       },
     });
-    return <ModelDescriptionField control={control} />;
+    return <ModelDescriptionField control={control} readOnly={readOnly} />;
   };
 
   render(<DescriptionForm />);
@@ -47,5 +47,12 @@ describe('<ModelDescriptionField />', () => {
     expect(input.value).toHaveLength(200);
 
     expect(getHelpTextNode()).toHaveTextContent('0 characters left');
+  });
+
+  it('should set textarea to readOnly and hide help text', async () => {
+    const { input, getHelpTextNode } = setup('foo', true);
+
+    expect(input).toHaveAttribute('readonly');
+    expect(getHelpTextNode()).not.toBeInTheDocument();
   });
 });

--- a/public/components/common/forms/__tests__/model_description_field.test.tsx
+++ b/public/components/common/forms/__tests__/model_description_field.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import userEvent from '@testing-library/user-event';
+
+import { render, screen } from '../../../../../test/test_utils';
+
+import { ModelDescriptionField } from '../model_description_field';
+
+const setup = (description: string = '') => {
+  const DescriptionForm = () => {
+    const { control } = useForm({
+      defaultValues: {
+        description,
+      },
+    });
+    return <ModelDescriptionField control={control} />;
+  };
+
+  render(<DescriptionForm />);
+
+  const input = screen.getByLabelText<HTMLTextAreaElement>(/description/i);
+
+  return {
+    input,
+    getHelpTextNode: () => input.nextSibling,
+  };
+};
+
+describe('<ModelDescriptionField />', () => {
+  it('should render "Description" title, content and "200 characters allowed" by default', () => {
+    const { input, getHelpTextNode } = setup();
+    expect(screen.getByText(/Description/i)).toBeInTheDocument();
+    expect(input).toHaveValue('');
+    expect(getHelpTextNode()).toHaveTextContent('200 characters allowed');
+  });
+
+  it('should display 200 characters and show "0 characters left" after input 201 characters', async () => {
+    const { input, getHelpTextNode } = setup();
+
+    await userEvent.type(input, 'x'.repeat(201));
+
+    expect(input.value).toHaveLength(200);
+
+    expect(getHelpTextNode()).toHaveTextContent('0 characters left');
+  });
+});

--- a/public/components/common/forms/__tests__/model_name_field.test.tsx
+++ b/public/components/common/forms/__tests__/model_name_field.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import userEvent from '@testing-library/user-event';
+
+import { render, screen } from '../../../../../test/test_utils';
+
+import { ModelNameField } from '../model_name_field';
+
+const setup = (name: string = '') => {
+  const NameForm = () => {
+    const { control, trigger } = useForm({
+      mode: 'onChange',
+      defaultValues: {
+        name,
+      },
+    });
+    return <ModelNameField control={control} trigger={trigger} />;
+  };
+
+  render(<NameForm />);
+
+  const input = screen.getByLabelText<HTMLInputElement>(/name/i);
+
+  return {
+    input,
+    getHelpTextNode: () => input.closest('.euiFormRow')?.querySelector('.euiFormHelpText'),
+    getErrorMessageNode: () => input.closest('.euiFormRow')?.querySelector('.euiFormErrorText'),
+  };
+};
+
+describe('<ModelNameField />', () => {
+  it('should render "Name" title, content and "80 characters allowed" by default', () => {
+    const { input, getHelpTextNode } = setup();
+    expect(screen.getByText(/Name/i)).toBeInTheDocument();
+    expect(input).toHaveValue('');
+    expect(getHelpTextNode()).toHaveTextContent('80 characters allowed');
+  });
+
+  it('should show 80 characters and "0 characters left" after 81 characters input', async () => {
+    const { input, getHelpTextNode } = setup();
+
+    await userEvent.type(input, 'x'.repeat(81));
+    expect(input.value).toHaveLength(80);
+    expect(getHelpTextNode()).toHaveTextContent('0 characters left');
+  });
+
+  it('should show "Name can not be empty" error message after name be cleared', async () => {
+    const { input, getErrorMessageNode } = setup('12345');
+
+    await userEvent.clear(input);
+
+    expect(getErrorMessageNode()).toHaveTextContent('Name can not be empty');
+  });
+
+  it('should show "This name is already in use. Use a unique name for the model." after name duplicated', async () => {
+    const { input, getErrorMessageNode } = setup('12345');
+
+    await userEvent.clear(input);
+    await userEvent.type(input, 'model1');
+    // mock user blur
+    await userEvent.click(screen.getByText('Name'));
+
+    expect(getErrorMessageNode()).toHaveTextContent(
+      'This name is already in use. Use a unique name for the model.'
+    );
+  });
+});

--- a/public/components/common/forms/error_call_out.tsx
+++ b/public/components/common/forms/error_call_out.tsx
@@ -5,24 +5,28 @@
 
 import { EuiCallOut, EuiText } from '@elastic/eui';
 import React, { useMemo } from 'react';
-import { useFormContext } from 'react-hook-form';
-import { FORM_ERRORS } from './constants';
+import { FieldErrors } from 'react-hook-form';
 
-import type { ModelFileFormData, ModelUrlFormData } from './register_model.types';
+interface ErrorCallOutProps {
+  formErrors: FieldErrors;
+  errorMessages: Array<{
+    field: string;
+    type: string;
+    message: string;
+  }>;
+}
 
-export const ErrorCallOut = () => {
-  const form = useFormContext<ModelFileFormData | ModelUrlFormData>();
-
+export const ErrorCallOut = ({ formErrors, errorMessages }: ErrorCallOutProps) => {
   const errors = useMemo(() => {
     const messages: string[] = [];
-    Object.keys(form.formState.errors).forEach((errorField) => {
-      const error = form.formState.errors[errorField as keyof typeof form.formState.errors];
+    Object.keys(formErrors).forEach((errorField) => {
+      const error = formErrors[errorField as keyof typeof formErrors];
       // If form have: criteriaMode: 'all', error.types will be set a value
       // error.types will contain all the errors of each field
       // In this case, we will display all the errors in the callout
       if (error?.types) {
         Object.keys(error.types).forEach((k) => {
-          const errorMessage = FORM_ERRORS.find((e) => e.field === errorField && e.type === k);
+          const errorMessage = errorMessages.find((e) => e.field === errorField && e.type === k);
           if (errorMessage) {
             messages.push(errorMessage.message);
           }
@@ -32,7 +36,7 @@ export const ErrorCallOut = () => {
         // to only produce the first error, even if a field has multiple errors.
         // In this case, error.types won't be set, and error.type and error.field represent the
         // first error
-        const errorMessage = FORM_ERRORS.find(
+        const errorMessage = errorMessages.find(
           (e) => e.field === errorField && e.type === error?.type
         );
         if (errorMessage) {
@@ -41,7 +45,7 @@ export const ErrorCallOut = () => {
       }
     });
     return messages;
-  }, [form]);
+  }, [formErrors, errorMessages]);
 
   if (errors.length === 0) {
     return null;
@@ -55,7 +59,7 @@ export const ErrorCallOut = () => {
       iconType="iInCircle"
     >
       <EuiText size="s">
-        <ul style={{ listStyle: 'none', margin: 0 }}>
+        <ul style={{ listStyle: 'inside', margin: 0, marginLeft: 6 }}>
           {errors.map((e) => (
             <li key={e}>- {e}</li>
           ))}

--- a/public/components/common/forms/error_call_out.tsx
+++ b/public/components/common/forms/error_call_out.tsx
@@ -61,7 +61,7 @@ export const ErrorCallOut = ({ formErrors, errorMessages }: ErrorCallOutProps) =
       <EuiText size="s">
         <ul style={{ listStyle: 'inside', margin: 0, marginLeft: 6 }}>
           {errors.map((e) => (
-            <li key={e}>- {e}</li>
+            <li key={e}>{e}</li>
           ))}
         </ul>
       </EuiText>

--- a/public/components/common/forms/index.ts
+++ b/public/components/common/forms/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './model_description_field';
+export * from './model_name_field';
+export * from './error_call_out';

--- a/public/components/common/forms/model_description_field.tsx
+++ b/public/components/common/forms/model_description_field.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+
+import { EuiFormRow, EuiTextArea } from '@elastic/eui';
+import { Control, FieldPathByValue, useController } from 'react-hook-form';
+
+interface ModeDescriptionFormData {
+  description: string;
+}
+
+const DESCRIPTION_MAX_LENGTH = 200;
+
+interface ModelDescriptionFieldProps<TFieldValues extends ModeDescriptionFormData> {
+  control: Control<TFieldValues>;
+}
+
+export const ModelDescriptionField = <TFieldValues extends ModeDescriptionFormData>({
+  control,
+}: ModelDescriptionFieldProps<TFieldValues>) => {
+  const descriptionFieldController = useController({
+    name: 'description' as FieldPathByValue<TFieldValues, string>,
+    control,
+  });
+
+  const { ref: descriptionInputRef, ...descriptionField } = descriptionFieldController.field;
+
+  return (
+    <EuiFormRow
+      label={
+        <>
+          Description - <i style={{ fontWeight: 300 }}>optional</i>
+        </>
+      }
+      isInvalid={Boolean(descriptionFieldController.fieldState.error)}
+      error={descriptionFieldController.fieldState.error?.message}
+      helpText={`${Math.max(
+        DESCRIPTION_MAX_LENGTH - descriptionField.value.length,
+        0
+      )} characters ${descriptionField.value.length ? 'left' : 'allowed'}.`}
+    >
+      <EuiTextArea
+        inputRef={descriptionInputRef}
+        isInvalid={Boolean(descriptionFieldController.fieldState.error)}
+        maxLength={DESCRIPTION_MAX_LENGTH}
+        {...descriptionField}
+      />
+    </EuiFormRow>
+  );
+};

--- a/public/components/common/forms/model_description_field.tsx
+++ b/public/components/common/forms/model_description_field.tsx
@@ -16,10 +16,12 @@ const DESCRIPTION_MAX_LENGTH = 200;
 
 interface ModelDescriptionFieldProps<TFieldValues extends ModeDescriptionFormData> {
   control: Control<TFieldValues>;
+  readOnly?: boolean;
 }
 
 export const ModelDescriptionField = <TFieldValues extends ModeDescriptionFormData>({
   control,
+  readOnly,
 }: ModelDescriptionFieldProps<TFieldValues>) => {
   const descriptionFieldController = useController({
     name: 'description' as FieldPathByValue<TFieldValues, string>,
@@ -37,16 +39,19 @@ export const ModelDescriptionField = <TFieldValues extends ModeDescriptionFormDa
       }
       isInvalid={Boolean(descriptionFieldController.fieldState.error)}
       error={descriptionFieldController.fieldState.error?.message}
-      helpText={`${Math.max(
-        DESCRIPTION_MAX_LENGTH - descriptionField.value.length,
-        0
-      )} characters ${descriptionField.value.length ? 'left' : 'allowed'}.`}
+      helpText={
+        !readOnly &&
+        `${Math.max(DESCRIPTION_MAX_LENGTH - descriptionField.value.length, 0)} characters ${
+          descriptionField.value.length ? 'left' : 'allowed'
+        }.`
+      }
     >
       <EuiTextArea
         inputRef={descriptionInputRef}
         isInvalid={Boolean(descriptionFieldController.fieldState.error)}
         maxLength={DESCRIPTION_MAX_LENGTH}
         {...descriptionField}
+        readOnly={readOnly}
       />
     </EuiFormRow>
   );

--- a/public/components/common/forms/model_name_field.tsx
+++ b/public/components/common/forms/model_name_field.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useCallback, useRef } from 'react';
+import { EuiFieldText, EuiFormRow, EuiText } from '@elastic/eui';
+import { Control, FieldPathByValue, UseFormTrigger, useController } from 'react-hook-form';
+
+import { APIProvider } from '../../../apis/api_provider';
+
+export const MODEL_NAME_FIELD_DUPLICATE_NAME_ERROR = 'duplicateName';
+
+const NAME_MAX_LENGTH = 80;
+
+interface ModelNameFormData {
+  name: string;
+}
+
+interface ModelNameFieldProps<TFieldValues extends ModelNameFormData> {
+  control: Control<TFieldValues>;
+  trigger: UseFormTrigger<TFieldValues>;
+}
+
+const isDuplicateModelName = async (name: string) => {
+  const searchResult = await APIProvider.getAPI('model').search({
+    name,
+    from: 0,
+    size: 1,
+  });
+  return searchResult.total_models >= 1;
+};
+
+export const ModelNameField = <TFieldValues extends ModelNameFormData>({
+  control,
+  trigger,
+}: ModelNameFieldProps<TFieldValues>) => {
+  const modelNameFocusedRef = useRef(false);
+  const nameFieldController = useController({
+    name: 'name' as FieldPathByValue<TFieldValues, string>,
+    control,
+    rules: {
+      required: { value: true, message: 'Name can not be empty' },
+      validate: {
+        [MODEL_NAME_FIELD_DUPLICATE_NAME_ERROR]: async (name) => {
+          return !modelNameFocusedRef.current && !!name && (await isDuplicateModelName(name))
+            ? 'This name is already in use. Use a unique name for the model.'
+            : undefined;
+        },
+      },
+    },
+  });
+
+  const { ref: nameInputRef, ...nameField } = nameFieldController.field;
+
+  const handleModelNameFocus = useCallback(() => {
+    modelNameFocusedRef.current = true;
+  }, []);
+
+  const handleModelNameBlur = useCallback(() => {
+    nameField.onBlur();
+    modelNameFocusedRef.current = false;
+    trigger('name' as FieldPathByValue<TFieldValues, string>);
+  }, [nameField, trigger]);
+
+  return (
+    <EuiFormRow
+      label="Name"
+      isInvalid={Boolean(nameFieldController.fieldState.error)}
+      error={nameFieldController.fieldState.error?.message}
+      helpText={
+        <EuiText color="subdued" size="xs">
+          {Math.max(NAME_MAX_LENGTH - nameField.value.length, 0)} characters{' '}
+          {nameField.value.length ? 'left' : 'allowed'}.
+          <br />
+          Use a unique for the model.
+        </EuiText>
+      }
+    >
+      <EuiFieldText
+        inputRef={nameInputRef}
+        isInvalid={Boolean(nameFieldController.fieldState.error)}
+        maxLength={NAME_MAX_LENGTH}
+        {...nameField}
+        onFocus={handleModelNameFocus}
+        onBlur={handleModelNameBlur}
+      />
+    </EuiFormRow>
+  );
+};

--- a/public/components/common/index.ts
+++ b/public/components/common/index.ts
@@ -10,3 +10,4 @@ export * from './selected_tag_filter_panel';
 export * from './debounced_search_bar';
 export * from './tag_filter';
 export * from './options_filter';
+export * from './forms';

--- a/public/components/model/__tests__/bottom_form_action_bar.test.tsx
+++ b/public/components/model/__tests__/bottom_form_action_bar.test.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+
+import { render, screen } from '../../../../test/test_utils';
+import { BottomFormActionBar } from '../bottom_form_action_bar';
+
+describe('<BottomFormActionBar />', () => {
+  it('should display consistent unsaved changes and error count', () => {
+    render(
+      <BottomFormActionBar
+        unSavedChangeCount={2}
+        errorCount={1}
+        onDiscardButtonClick={jest.fn()}
+        formId="test-form-id"
+      />
+    );
+
+    expect(screen.getByText('2 unsaved change(s)')).toBeInTheDocument();
+    expect(screen.getByText('1 error(s)')).toBeInTheDocument();
+  });
+
+  it('should call onDiscardButtonClick when discard button is clicked', async () => {
+    const onDiscardButtonClickMock = jest.fn();
+    render(
+      <BottomFormActionBar onDiscardButtonClick={onDiscardButtonClickMock} formId="test-form-id" />
+    );
+
+    expect(onDiscardButtonClickMock).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByText('Discard change(s)'));
+    expect(onDiscardButtonClickMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should submit form after save button clicked', async () => {
+    const formId = 'test-form-id';
+    const onSubmitMock = jest.fn((e) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmitMock} id={formId}>
+        <BottomFormActionBar onDiscardButtonClick={jest.fn()} formId={formId} />
+      </form>
+    );
+
+    expect(onSubmitMock).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByText('Save'));
+    expect(onSubmitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should disabled save button and show loading indicator', () => {
+    render(
+      <BottomFormActionBar
+        onDiscardButtonClick={jest.fn()}
+        formId="test-form-id"
+        isSaveButtonDisabled={true}
+        isSaveButtonLoading={true}
+      />
+    );
+
+    expect(screen.getByText('Save').closest('button')).toBeDisabled();
+    expect(screen.getByText('Save').previousSibling).toHaveClass('euiLoadingSpinner');
+  });
+});

--- a/public/components/model/__tests__/model.test.tsx
+++ b/public/components/model/__tests__/model.test.tsx
@@ -66,4 +66,19 @@ describe('<Model />', () => {
     },
     10 * 1000
   );
+
+  it(
+    'should display model name in details tab',
+    async () => {
+      setup();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('model-group-loading-indicator')).toBeNull();
+      });
+      await userEvent.click(screen.getByRole('tab', { name: 'Details' }));
+
+      expect(within(screen.getByRole('tabpanel')).getByDisplayValue('model1')).toBeInTheDocument();
+    },
+    10 * 1000
+  );
 });

--- a/public/components/model/__tests__/model_details_panel.test.tsx
+++ b/public/components/model/__tests__/model_details_panel.test.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+
+import { act, render, screen, within } from '../../../../test/test_utils';
+import { ModelDetailsPanel } from '../model_details_panel';
+
+import * as PluginContext from '../../../../../../src/plugins/opensearch_dashboards_react/public';
+
+// Cannot spyOn(PluginContext, 'useOpenSearchDashboards') directly as it results in error:
+// TypeError: Cannot redefine property: useOpenSearchDashboards
+// So we have to mock the entire module first as a workaround
+jest.mock('../../../../../../src/plugins/opensearch_dashboards_react/public', () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual('../../../../../../src/plugins/opensearch_dashboards_react/public'),
+  };
+});
+
+describe('<ModelDetailsPanel />', () => {
+  it('should render edit button and name, description in read-only mode by default', () => {
+    render(<ModelDetailsPanel id="1" name="model-1" description="model-1 description" />);
+
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('model-1')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('model-1')).toHaveAttribute('readonly');
+    expect(screen.getByText('model-1 description')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('model-1 description')).toHaveAttribute('readonly');
+  });
+
+  it('should turn edit mode on when edit button is clicked', async () => {
+    render(<ModelDetailsPanel id="1" name="model-1" description="model-1 description" />);
+
+    await userEvent.click(screen.getByText('Edit'));
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+
+    expect(screen.getByDisplayValue('model-1')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('model-1')).not.toHaveAttribute('readonly');
+    expect(screen.getByText(/Use a unique name for the model./)).toBeInTheDocument();
+
+    expect(screen.getByText('model-1 description')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('model-1 description')).not.toHaveAttribute('readonly');
+  });
+
+  it('should NOT allow type more than 80 characters and show 0 characters left for name', async () => {
+    render(<ModelDetailsPanel id="1" name={'model-1'} />);
+
+    const nameInput = screen.getByLabelText(/Name/);
+
+    await userEvent.click(screen.getByText('Edit'));
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'x'.repeat(81));
+    expect((nameInput as HTMLInputElement).value).toHaveLength(80);
+    expect(
+      within(nameInput.closest('.euiFormRow')!).getByText(/0 characters left./)
+    ).toBeInTheDocument();
+  });
+
+  it('should NOT allow input characters more than 200 and show 0 characters left for description', async () => {
+    render(<ModelDetailsPanel id="1" name={'model-1'} />);
+
+    const descriptionInput = screen.getByLabelText(/Description/);
+
+    await userEvent.click(screen.getByText('Edit'));
+    await userEvent.clear(descriptionInput);
+    await userEvent.type(descriptionInput, 'x'.repeat(201));
+    expect((descriptionInput as HTMLInputElement).value).toHaveLength(200);
+    expect(
+      within(descriptionInput.closest('.euiFormRow')!).getByText(/0 characters left./)
+    ).toBeInTheDocument();
+  });
+
+  it('should show unsaved changes count, error count, discard changes and save button after name input value cleared', async () => {
+    render(<ModelDetailsPanel id="1" name="model-1" description="model-1 description" />);
+
+    await userEvent.click(screen.getByText('Edit'));
+    await userEvent.clear(screen.getByDisplayValue('model-1'));
+
+    expect(screen.getByText('1 error(s)')).toBeInTheDocument();
+    expect(screen.getByText('1 unsaved change(s)')).toBeInTheDocument();
+    expect(screen.getByText('Discard change(s)')).toBeInTheDocument();
+    expect(screen.getByText('Save')).toBeInTheDocument();
+  });
+
+  it('should reset to default name description after discard changes button clicked', async () => {
+    render(<ModelDetailsPanel id="1" name="model-1" />);
+
+    const nameInput = screen.getByLabelText(/Name/);
+    const descriptionInput = screen.getByLabelText(/Description/);
+
+    await userEvent.click(screen.getByText('Edit'));
+    await userEvent.type(nameInput, 'updated');
+    await userEvent.type(descriptionInput, 'description of model-1');
+
+    await userEvent.click(screen.getByText('Discard change(s)'));
+    expect(nameInput).toHaveValue('model-1');
+    expect(descriptionInput).toHaveValue('');
+  });
+
+  it('should show error callout after save button clicked', async () => {
+    render(<ModelDetailsPanel id="1" name="model-1" />);
+
+    await userEvent.click(screen.getByText('Edit'));
+    await userEvent.clear(screen.getByDisplayValue('model-1'));
+    await userEvent.click(screen.getByText('Save'));
+
+    expect(screen.getByText('Address the following error(s) in the form')).toBeInTheDocument();
+    expect(screen.getByText('Name: can not be empty')).toBeInTheDocument();
+  });
+
+  it('should call addSuccessToast after form submit successfully', async () => {
+    const addSuccessMock = jest.fn();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    jest.useFakeTimers();
+
+    const opensearchDashboardsMock = jest
+      .spyOn(PluginContext, 'useOpenSearchDashboards')
+      .mockReturnValue({
+        services: {
+          notifications: {
+            toasts: {
+              addSuccess: addSuccessMock,
+            },
+          },
+        },
+      });
+
+    render(<ModelDetailsPanel id="1" name="model-1" />);
+
+    await user.click(screen.getByText('Edit'));
+    await user.type(screen.getByDisplayValue('model-1'), 'updated');
+    await user.click(screen.getByText('Save'));
+
+    // TODO: Remove it after integrated real model update API
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(addSuccessMock).toHaveBeenCalledTimes(1);
+
+    jest.useRealTimers();
+    opensearchDashboardsMock.mockRestore();
+  });
+});

--- a/public/components/model/__tests__/model_details_panel.test.tsx
+++ b/public/components/model/__tests__/model_details_panel.test.tsx
@@ -109,7 +109,7 @@ describe('<ModelDetailsPanel />', () => {
     await userEvent.click(screen.getByText('Save'));
 
     expect(screen.getByText('Address the following error(s) in the form')).toBeInTheDocument();
-    expect(screen.getByText('Name: can not be empty')).toBeInTheDocument();
+    expect(screen.getByText('Name: Enter a name.')).toBeInTheDocument();
   });
 
   it('should call addSuccessToast after form submit successfully', async () => {

--- a/public/components/model/__tests__/model_overview_card.test.tsx
+++ b/public/components/model/__tests__/model_overview_card.test.tsx
@@ -37,4 +37,19 @@ describe('<ModelOverviewCard />', () => {
       within(screen.getByText('model-1-id')).getByTestId('copy-id-button')
     ).toBeInTheDocument();
   });
+
+  it('should display "-" for empty description', () => {
+    render(
+      <ModelOverviewCard
+        id="model-1-id"
+        isModelOwner
+        owner="Foo"
+        createdTime={1682324310318}
+        updatedTime={1682342310318}
+      />
+    );
+    expect(
+      within(screen.getByText('Description').closest('dl')!).getByText('-')
+    ).toBeInTheDocument();
+  });
 });

--- a/public/components/model/bottom_form_action_bar.tsx
+++ b/public/components/model/bottom_form_action_bar.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiBottomBar,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+} from '@elastic/eui';
+import useObservable from 'react-use/lib/useObservable';
+import { from } from 'rxjs';
+
+import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
+
+interface BottomFormActionBarProps {
+  formId: string;
+  errorCount?: number;
+  unSavedChangeCount?: number;
+  onDiscardButtonClick: () => void;
+  isSaveButtonLoading?: boolean;
+  isSaveButtonDisabled?: boolean;
+}
+
+export const BottomFormActionBar = ({
+  formId,
+  errorCount = 0,
+  unSavedChangeCount = 0,
+  onDiscardButtonClick,
+  isSaveButtonDisabled,
+  isSaveButtonLoading,
+}: BottomFormActionBarProps) => {
+  const {
+    services: { chrome },
+  } = useOpenSearchDashboards();
+  const isLocked = useObservable(chrome?.getIsNavDrawerLocked$() ?? from([false]));
+
+  return (
+    <EuiBottomBar left={isLocked ? '320px' : 0}>
+      <EuiFlexGroup alignItems="center" gutterSize="none" justifyContent="spaceBetween">
+        <EuiFlexGroup alignItems="center" gutterSize="m">
+          {errorCount > 0 && (
+            <EuiFlexItem grow={false}>
+              <EuiText style={{ padding: '0 8px', borderLeft: '4px solid #BD271E' }}>
+                {errorCount} error(s)
+              </EuiText>
+            </EuiFlexItem>
+          )}
+          {unSavedChangeCount > 0 && (
+            <EuiFlexItem grow={false}>
+              <EuiText style={{ padding: '0 8px', borderLeft: '4px solid #F5A700' }}>
+                {unSavedChangeCount} unsaved change(s)
+              </EuiText>
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+        <EuiFlexGroup alignItems="center" gutterSize="s" justifyContent="flexEnd">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty color="ghost" iconType="cross" onClick={onDiscardButtonClick}>
+              Discard change(s)
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              form={formId}
+              iconType="check"
+              size="s"
+              color="primary"
+              type="submit"
+              fill
+              minWidth={87}
+              isLoading={isSaveButtonLoading}
+              isDisabled={isSaveButtonDisabled}
+            >
+              Save
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexGroup>
+    </EuiBottomBar>
+  );
+};

--- a/public/components/model/model.tsx
+++ b/public/components/model/model.tsx
@@ -39,10 +39,11 @@ export const Model = () => {
       {
         name: 'Details',
         id: 'details',
+        // TODO: Add description property here
         content: (
           <>
             <EuiSpacer size="m" />
-            <ModelDetailsPanel />
+            <ModelDetailsPanel name={data?.name} id={modelId} />
           </>
         ),
       },
@@ -57,7 +58,7 @@ export const Model = () => {
         ),
       },
     ],
-    [modelId]
+    [modelId, data]
   );
   const [selectedTabId, setSelectedTabId] = useState(tabs[0].id);
 

--- a/public/components/model/model.tsx
+++ b/public/components/model/model.tsx
@@ -12,7 +12,7 @@ import {
   EuiTabbedContentTab,
   EuiText,
 } from '@elastic/eui';
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { useFetcher } from '../../hooks';
 import { APIProvider } from '../../apis/api_provider';
@@ -59,7 +59,11 @@ export const Model = () => {
     ],
     [modelId]
   );
-  const [selectedTab, setSelectedTab] = useState<EuiTabbedContentTab>(tabs[0]);
+  const [selectedTabId, setSelectedTabId] = useState(tabs[0].id);
+
+  const handleTabClick = useCallback((tab: EuiTabbedContentTab) => {
+    setSelectedTabId(tab.id);
+  }, []);
 
   if (loading) {
     // TODO: need to update per design
@@ -93,7 +97,11 @@ export const Model = () => {
         // TODO: Add description property here
       />
       <EuiSpacer size="l" />
-      <EuiTabbedContent tabs={tabs} onTabClick={setSelectedTab} selectedTab={selectedTab} />
+      <EuiTabbedContent
+        tabs={tabs}
+        onTabClick={handleTabClick}
+        selectedTab={tabs.find((tab) => tab.id === selectedTabId)}
+      />
     </>
   );
 };

--- a/public/components/model/model_details_panel.tsx
+++ b/public/components/model/model_details_panel.tsx
@@ -3,17 +3,242 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { EuiHorizontalRule, EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
+import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiDescribedFormGroup,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiForm,
+  EuiFormRow,
+  EuiHorizontalRule,
+  EuiLink,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTextArea,
+  EuiTitle,
+  htmlIdGenerator,
+} from '@elastic/eui';
+import { useController, useForm } from 'react-hook-form';
+import { generatePath, useHistory } from 'react-router-dom';
 
-export const ModelDetailsPanel = () => {
+import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
+import { mountReactNode } from '../../../../../src/core/public/utils';
+import { routerPaths } from '../../../common';
+
+import { BottomFormActionBar } from './bottom_form_action_bar';
+
+const NAME_MAX_LENGTH = 80;
+
+const DESCRIPTION_MAX_LENGTH = 200;
+
+interface ModelDetailsProps {
+  id: string;
+  name?: string;
+  description?: string;
+  onDetailsUpdate?: (formData: { name: string; description?: string }) => void;
+}
+
+export const ModelDetailsPanel = ({
+  id,
+  name,
+  description,
+  onDetailsUpdate,
+}: ModelDetailsProps) => {
+  const formIdRef = useRef(htmlIdGenerator()());
+  const history = useHistory();
+  const { control, resetField, formState, handleSubmit } = useForm({
+    mode: 'onChange',
+    defaultValues: {
+      name: '',
+      description: '',
+    },
+  });
+  const [isEditMode, setIsEditMode] = useState(false);
+  const {
+    services: { notifications },
+  } = useOpenSearchDashboards();
+
+  const nameController = useController({
+    control,
+    name: 'name',
+    rules: {
+      required: { value: true, message: 'Name can not be empty' },
+    },
+  });
+  const { ref: nameInputRef, ...restNameFieldProps } = nameController.field;
+
+  const descriptionController = useController({
+    control,
+    name: 'description',
+  });
+  const { ref: descriptionInputRef, ...restDescriptionFieldProps } = descriptionController.field;
+
+  const formErrorCalloutTexts = useMemo(() => {
+    const errors = [];
+    if (formState.errors.name && formState.errors.name.type === 'required') {
+      errors.push('Name: can not be empty');
+    }
+    return errors;
+  }, [formState]);
+
+  const handleFormSubmit = useMemo(
+    () =>
+      handleSubmit(async (formData) => {
+        // TODO: Just for mock form submit, need to use model update API after integrated
+        await new Promise((resolve) => {
+          window.setTimeout(resolve, 1000);
+        });
+        notifications?.toasts.addSuccess({
+          title: mountReactNode(
+            <EuiText>
+              Updated{' '}
+              <EuiLink
+                onClick={() => {
+                  history.push(
+                    generatePath(routerPaths.modelGroup, {
+                      id,
+                    })
+                  );
+                }}
+              >
+                {formData.name}
+              </EuiLink>
+            </EuiText>
+          ),
+        });
+        setIsEditMode(false);
+        onDetailsUpdate?.(formData);
+        resetField('name', { defaultValue: formData.name || '' });
+        resetField('description', { defaultValue: formData.description || '' });
+      }),
+    [id, history, notifications, resetField, handleSubmit, setIsEditMode, onDetailsUpdate]
+  );
+
+  const resetAllFields = useCallback(() => {
+    resetField('name', { defaultValue: name || '' });
+    resetField('description', { defaultValue: description || '' });
+  }, [name, description, resetField]);
+
+  const handleEditClick = useCallback(() => {
+    setIsEditMode(true);
+  }, []);
+
+  const handleCancelClick = useCallback(() => {
+    resetAllFields();
+    setIsEditMode(false);
+  }, [resetAllFields]);
+
+  useEffect(() => {
+    resetField('name', { defaultValue: name || '' });
+    resetField('description', { defaultValue: description || '' });
+  }, [name, description, resetField]);
+
   return (
     <EuiPanel style={{ padding: 20 }}>
-      <EuiTitle size="s">
-        <h3>Details</h3>
-      </EuiTitle>
+      <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
+        <EuiFlexItem>
+          <EuiTitle size="s">
+            <h3>Details</h3>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButton onClick={isEditMode ? handleCancelClick : handleEditClick}>
+            {isEditMode ? 'Cancel' : 'Edit'}
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
       <EuiSpacer size="m" />
       <EuiHorizontalRule margin="none" />
+      <EuiSpacer size="m" />
+      {formState.isSubmitted && formErrorCalloutTexts.length > 0 && (
+        <>
+          <EuiCallOut
+            iconType="alert"
+            color="danger"
+            title="Address the following error(s) in the form"
+          >
+            <EuiText size="s">
+              <ul style={{ listStyle: 'inside', marginLeft: 6 }}>
+                {formErrorCalloutTexts.map((text) => (
+                  <li key={text}>{text}</li>
+                ))}
+              </ul>
+            </EuiText>
+          </EuiCallOut>
+          <EuiSpacer size="l" />
+        </>
+      )}
+      <EuiForm component="form" id={formIdRef.current} onSubmit={handleFormSubmit}>
+        <EuiDescribedFormGroup title={<h4>Name</h4>}>
+          <EuiFormRow
+            helpText={
+              isEditMode && (
+                <>
+                  {`${Math.max(
+                    NAME_MAX_LENGTH - (restNameFieldProps.value?.length ?? 0),
+                    0
+                  )} characters ${restNameFieldProps.value?.length ? 'left' : 'allowed'}.`}
+                  <br />
+                  Use a unique name for the model.
+                </>
+              )
+            }
+            isInvalid={Boolean(nameController.fieldState.error)}
+            error={nameController.fieldState.error?.message}
+            label="Name"
+          >
+            <EuiFieldText
+              inputRef={nameInputRef}
+              aria-label="Name"
+              readOnly={!isEditMode}
+              maxLength={NAME_MAX_LENGTH}
+              {...restNameFieldProps}
+            />
+          </EuiFormRow>
+        </EuiDescribedFormGroup>
+        <EuiDescribedFormGroup
+          title={
+            <h4>
+              Description <i style={{ fontWeight: 400 }}> - optional</i>
+            </h4>
+          }
+          description="Describe the model."
+        >
+          <EuiFormRow
+            helpText={
+              isEditMode &&
+              `${Math.max(
+                DESCRIPTION_MAX_LENGTH - (restDescriptionFieldProps.value?.length ?? 0),
+                0
+              )} characters ${restDescriptionFieldProps.value?.length ? 'left' : 'allowed'}.`
+            }
+            isInvalid={Boolean(descriptionController.fieldState.error)}
+            error={descriptionController.fieldState.error?.message}
+            label="Description"
+          >
+            <EuiTextArea
+              aria-label="Description"
+              readOnly={!isEditMode}
+              maxLength={DESCRIPTION_MAX_LENGTH}
+              {...restDescriptionFieldProps}
+            />
+          </EuiFormRow>
+        </EuiDescribedFormGroup>
+        {(formState.dirtyFields.name || formState.dirtyFields.description) && (
+          <BottomFormActionBar
+            unSavedChangeCount={Object.keys(formState.dirtyFields).length}
+            errorCount={Object.keys(formState.errors).length}
+            formId={formIdRef.current}
+            onDiscardButtonClick={resetAllFields}
+            isSaveButtonDisabled={formState.isSubmitting}
+            isSaveButtonLoading={formState.isSubmitting}
+          />
+        )}
+      </EuiForm>
     </EuiPanel>
   );
 };

--- a/public/components/model/model_overview_card.tsx
+++ b/public/components/model/model_overview_card.tsx
@@ -33,7 +33,7 @@ export const ModelOverviewCard = ({
         listItems={[
           {
             title: 'Description',
-            description: description || '',
+            description: description || '-',
           },
         ]}
       />

--- a/public/components/model/model_versions_panel/__tests__/model_versions_panel.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_versions_panel.test.tsx
@@ -30,7 +30,7 @@ describe('<ModelVersionsPanel />', () => {
       await waitFor(() => {
         expect(
           screen.getByText((text, node) => {
-            return text === 'Versions' && !!node?.childNodes[1]?.textContent?.includes('(3)');
+            return text === 'Versions' && !!node?.childNodes[1]?.textContent?.includes('(1)');
           })
         ).toBeInTheDocument();
       });

--- a/public/components/model_version/__tests__/model_version.test.tsx
+++ b/public/components/model_version/__tests__/model_version.test.tsx
@@ -61,7 +61,7 @@ describe('<ModelVersion />', () => {
     await waitFor(() => {
       expect(screen.getByText('v1.0.1')).toBeInTheDocument();
     });
-    expect(location.pathname).toBe('/model-registry/model-version/2');
+    expect(location.pathname).toBe('/model-registry/model-version/4');
 
     mockReset();
   });

--- a/public/components/model_version/__tests__/version_toggler.test.tsx
+++ b/public/components/model_version/__tests__/version_toggler.test.tsx
@@ -39,7 +39,7 @@ describe('<VersionToggler />', () => {
     await user.click(screen.getByText('1.0.1'));
     expect(onVersionChange).toHaveBeenCalledWith({
       newVersion: '1.0.1',
-      newId: '2',
+      newId: '4',
     });
   });
 });

--- a/public/components/register_model/constants.ts
+++ b/public/components/register_model/constants.ts
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { ONE_GB } from '../../../common/constant';
+import { MODEL_NAME_FIELD_DUPLICATE_NAME_ERROR } from '../../components/common';
 
 export const MAX_CHUNK_SIZE = 10 * 1000 * 1000;
 export const MAX_MODEL_FILE_SIZE = 4 * ONE_GB;
 
 export enum CUSTOM_FORM_ERROR_TYPES {
-  DUPLICATE_NAME = 'duplicateName',
+  DUPLICATE_NAME = MODEL_NAME_FIELD_DUPLICATE_NAME_ERROR,
   FILE_SIZE_EXCEED_LIMIT = 'fileSizeExceedLimit',
   INVALID_CONFIGURATION = 'invalidConfiguration',
   CONFIGURATION_MISSING_MODEL_TYPE = 'configurationMissingModelType',
@@ -25,7 +26,7 @@ export const FORM_ERRORS = [
   },
   {
     field: 'name',
-    type: CUSTOM_FORM_ERROR_TYPES.DUPLICATE_NAME,
+    type: MODEL_NAME_FIELD_DUPLICATE_NAME_ERROR,
     message: 'Name: Use a unique name.',
   },
   {

--- a/public/components/register_model/model_details.tsx
+++ b/public/components/register_model/model_details.tsx
@@ -3,108 +3,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useRef } from 'react';
-import { EuiFieldText, EuiFormRow, EuiTextArea, EuiText } from '@elastic/eui';
-import { useController, useFormContext } from 'react-hook-form';
+import React from 'react';
+import { EuiText } from '@elastic/eui';
+import { useFormContext } from 'react-hook-form';
+
+import { ModelNameField, ModelDescriptionField } from '../../components/common';
+
 import { ModelFileFormData, ModelUrlFormData } from './register_model.types';
-import { APIProvider } from '../../apis/api_provider';
-import { CUSTOM_FORM_ERROR_TYPES } from './constants';
-
-const NAME_MAX_LENGTH = 80;
-const DESCRIPTION_MAX_LENGTH = 200;
-
-const isDuplicateModelName = async (name: string) => {
-  const searchResult = await APIProvider.getAPI('model').search({
-    name,
-    from: 0,
-    size: 1,
-  });
-  return searchResult.total_models >= 1;
-};
 
 export const ModelDetailsPanel = () => {
   const { control, trigger } = useFormContext<ModelFileFormData | ModelUrlFormData>();
-  const modelNameFocusedRef = useRef(false);
-  const nameFieldController = useController({
-    name: 'name',
-    control,
-    rules: {
-      required: { value: true, message: 'Name can not be empty' },
-      validate: {
-        [CUSTOM_FORM_ERROR_TYPES.DUPLICATE_NAME]: async (name) => {
-          return !modelNameFocusedRef.current && !!name && (await isDuplicateModelName(name))
-            ? 'This name is already in use. Use a unique name for the model.'
-            : undefined;
-        },
-      },
-    },
-  });
-
-  const descriptionFieldController = useController({
-    name: 'description',
-    control,
-  });
-
-  const { ref: nameInputRef, ...nameField } = nameFieldController.field;
-  const { ref: descriptionInputRef, ...descriptionField } = descriptionFieldController.field;
-
-  const handleModelNameFocus = useCallback(() => {
-    modelNameFocusedRef.current = true;
-  }, []);
-
-  const handleModelNameBlur = useCallback(() => {
-    nameField.onBlur();
-    modelNameFocusedRef.current = false;
-    trigger('name');
-  }, [nameField, trigger]);
 
   return (
     <div>
       <EuiText size="s">
         <h3>Details</h3>
       </EuiText>
-      <EuiFormRow
-        label="Name"
-        isInvalid={Boolean(nameFieldController.fieldState.error)}
-        error={nameFieldController.fieldState.error?.message}
-        helpText={
-          <EuiText color="subdued" size="xs">
-            {Math.max(NAME_MAX_LENGTH - nameField.value.length, 0)} characters{' '}
-            {nameField.value.length ? 'left' : 'allowed'}.
-            <br />
-            Use a unique for the model.
-          </EuiText>
-        }
-      >
-        <EuiFieldText
-          inputRef={nameInputRef}
-          isInvalid={Boolean(nameFieldController.fieldState.error)}
-          maxLength={NAME_MAX_LENGTH}
-          {...nameField}
-          onFocus={handleModelNameFocus}
-          onBlur={handleModelNameBlur}
-        />
-      </EuiFormRow>
-      <EuiFormRow
-        label={
-          <>
-            Description - <i style={{ fontWeight: 300 }}>optional</i>
-          </>
-        }
-        isInvalid={Boolean(descriptionFieldController.fieldState.error)}
-        error={descriptionFieldController.fieldState.error?.message}
-        helpText={`${Math.max(
-          DESCRIPTION_MAX_LENGTH - descriptionField.value.length,
-          0
-        )} characters ${descriptionField.value.length ? 'left' : 'allowed'}.`}
-      >
-        <EuiTextArea
-          inputRef={descriptionInputRef}
-          isInvalid={Boolean(descriptionFieldController.fieldState.error)}
-          maxLength={DESCRIPTION_MAX_LENGTH}
-          {...descriptionField}
-        />
-      </EuiFormRow>
+      <ModelNameField control={control} trigger={trigger} />
+      <ModelDescriptionField control={control} />
     </div>
   );
 };

--- a/public/components/register_model/register_model.tsx
+++ b/public/components/register_model/register_model.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState, useMemo } from 'react';
 import { FieldErrors, useForm, FormProvider } from 'react-hook-form';
 import { generatePath, useHistory, useParams } from 'react-router-dom';
 import {
@@ -24,25 +24,26 @@ import {
 import useObservable from 'react-use/lib/useObservable';
 import { from } from 'rxjs';
 
-import { ModelDetailsPanel } from './model_details';
-import type { ModelFileFormData, ModelUrlFormData } from './register_model.types';
-import { ArtifactPanel } from './artifact';
-import { ConfigurationPanel } from './model_configuration';
-import { ModelTagsPanel } from './model_tags';
-import { submitModelWithFile, submitModelWithURL } from './register_model_api';
 import { APIProvider } from '../../apis/api_provider';
 import { upgradeModelVersion } from '../../utils';
 import { useSearchParams } from '../../hooks/use_search_params';
 import { isValidModelRegisterFormType } from './utils';
 import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { mountReactNode } from '../../../../../src/core/public/utils';
-import { modelFileUploadManager } from './model_file_upload_manager';
-import { MAX_CHUNK_SIZE } from './constants';
 import { routerPaths } from '../../../common/router_paths';
+import { ErrorCallOut } from '../../components/common';
+import { modelRepositoryManager } from '../../utils/model_repository_manager';
+
 import { modelTaskManager } from './model_task_manager';
 import { ModelVersionNotesPanel } from './model_version_notes';
-import { modelRepositoryManager } from '../../utils/model_repository_manager';
-import { ErrorCallOut } from './error_call_out';
+import { modelFileUploadManager } from './model_file_upload_manager';
+import { MAX_CHUNK_SIZE, FORM_ERRORS } from './constants';
+import { ModelDetailsPanel } from './model_details';
+import type { ModelFileFormData, ModelUrlFormData } from './register_model.types';
+import { ArtifactPanel } from './artifact';
+import { ConfigurationPanel } from './model_configuration';
+import { ModelTagsPanel } from './model_tags';
+import { submitModelWithFile, submitModelWithURL } from './register_model_api';
 
 const DEFAULT_VALUES = {
   name: '',
@@ -110,6 +111,9 @@ export const RegisterModelForm = ({ defaultValues = DEFAULT_VALUES }: RegisterMo
     defaultValues,
     criteriaMode: 'all',
   });
+
+  // formState.errors won't change after formState updated, need to update errors object manually
+  const formErrors = useMemo(() => ({ ...form.formState.errors }), [form.formState]);
 
   const onSubmit = useCallback(
     async (data: ModelFileFormData | ModelUrlFormData) => {
@@ -312,7 +316,7 @@ export const RegisterModelForm = ({ defaultValues = DEFAULT_VALUES }: RegisterMo
             <EuiSpacer />
             {isSubmitted && !form.formState.isValid && (
               <>
-                <ErrorCallOut />
+                <ErrorCallOut formErrors={formErrors} errorMessages={FORM_ERRORS} />
                 <EuiSpacer />
               </>
             )}

--- a/test/mocks/model_handlers.ts
+++ b/test/mocks/model_handlers.ts
@@ -62,11 +62,40 @@ const models = [
     model_state: 'DEPLOYED',
     total_chunks: 34,
   },
+  {
+    id: '4',
+    name: 'model1',
+    model_version: '1.0.1',
+    description: 'model1 version 1.0.1 description',
+    created_time: 1683699469964,
+    last_registered_time: 1683699599632,
+    last_updated_time: 1683699599637,
+    model_config: {
+      all_config: '',
+      embedding_dimension: 768,
+      framework_type: 'SENTENCE_TRANSFORMERS',
+      model_type: 'roberta',
+    },
+    model_format: 'TORCH_SCRIPT',
+    model_state: 'DEPLOYED',
+    total_chunks: 34,
+  },
 ];
 
 export const modelHandlers = [
   rest.get(MODEL_API_ENDPOINT, (req, res, ctx) => {
-    const data = models.filter((model) => !req.params.name || model.name === req.params.name);
+    const { searchParams } = req.url;
+    const name = searchParams.get('name');
+    const ids = searchParams.getAll('ids');
+    const data = models.filter((model) => {
+      if (name) {
+        return model.name === name;
+      }
+      if (ids) {
+        return ids.includes(model.id);
+      }
+      return true;
+    });
     return res(
       ctx.status(200),
       ctx.json({


### PR DESCRIPTION
### Description
1. Render "-" if description is empty
2. Use tab id store selected tab
3. Add name and description input for details panel

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
