### PR TITLE
Fix: CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/ml-commons-dashboards
+# This should match the list in MAINTAINERS.md.
+* @ruanyl @wanglam @raintygao 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,9 +13,3 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Yulong Ruan | [ruanyl](https://github.com/ruanyl)       | Amazon      |
 | Lin Wang    | [wanglam](https://github.com/wanglam)     | Amazon      |
 | Tianyu Gao  | [raintygao](https://github.com/raintygao) | Amazon      |
-
-## Emeritus
-
-| Maintainer | GitHub ID | Affiliation |
-| ---------- | --------- | ----------- |
-


### PR DESCRIPTION
### Description

The group is going away, fixing the list.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
