### PR TITLE
Feature/add model version loading empty error screens

### DIFF
--- a/common/constant.ts
+++ b/common/constant.ts
@@ -7,5 +7,3 @@ export const ONE_MB = 1000 * 1000;
 export const ONE_GB = 1000 * ONE_MB;
 
 export const MAX_MODEL_CHUNK_SIZE = 10 * ONE_MB;
-
-export const DATE_FORMAT = 'MMM d, yyyy @ HH:mm:ss.SSS';

--- a/common/constant.ts
+++ b/common/constant.ts
@@ -7,3 +7,5 @@ export const ONE_MB = 1000 * 1000;
 export const ONE_GB = 1000 * ONE_MB;
 
 export const MAX_MODEL_CHUNK_SIZE = 10 * ONE_MB;
+
+export const DATE_FORMAT = 'MMM D, yyyy @ HH:mm:ss.SSS';

--- a/common/model.ts
+++ b/common/model.ts
@@ -49,13 +49,3 @@ export interface OpenSearchCustomerModel extends OpenSearchModelBase {
   version: number;
   planning_worker_nodes: string[];
 }
-
-export type ModelSearchSort =
-  | 'version-desc'
-  | 'version-asc'
-  | 'name-asc'
-  | 'name-desc'
-  | 'id-asc'
-  | 'model_state-asc'
-  | 'model_state-desc'
-  | 'id-desc';

--- a/public/apis/model.ts
+++ b/public/apis/model.ts
@@ -101,6 +101,7 @@ export class Model {
     size: number;
     states?: MODEL_STATE[];
     nameOrId?: string;
+    versionOrKeyword?: string;
   }) {
     return InnerHttpProvider.getHttp().get<ModelSearchResponse>(MODEL_API_ENDPOINT, {
       query,

--- a/public/apis/model.ts
+++ b/public/apis/model.ts
@@ -98,7 +98,7 @@ export class Model {
   public search(query: {
     algorithms?: string[];
     ids?: string[];
-    sort?: ModelSearchSort[];
+    sort?: string[];
     name?: string;
     from: number;
     size: number;

--- a/public/apis/model.ts
+++ b/public/apis/model.ts
@@ -33,6 +33,9 @@ export interface ModelSearchItem {
   };
   last_updated_time: number;
   created_time: number;
+  last_registered_time?: number;
+  last_deployed_time?: number;
+  last_undeployed_time?: number;
 }
 
 export interface ModelDetail extends ModelSearchItem {

--- a/public/components/common/__tests__/ui_setting_date_format_time.test.tsx
+++ b/public/components/common/__tests__/ui_setting_date_format_time.test.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+
+import * as PluginContext from '../../../../../../src/plugins/opensearch_dashboards_react/public';
+import { render, screen } from '../../../../test/test_utils';
+import { UiSettingDateFormatTime } from '../ui_setting_date_format_time';
+
+// Cannot spyOn(PluginContext, 'useOpenSearchDashboards') directly as it results in error:
+// TypeError: Cannot redefine property: useOpenSearchDashboards
+// So we have to mock the entire module first as a workaround
+jest.mock('../../../../../../src/plugins/opensearch_dashboards_react/public', () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual('../../../../../../src/plugins/opensearch_dashboards_react/public'),
+  };
+});
+
+describe('<UiSettingDateFormatTime />', () => {
+  it('should render "-" if time was undefined', () => {
+    render(<UiSettingDateFormatTime time={undefined} />);
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+
+  it('should render consistent time text based ui setting', () => {
+    const opensearchDashboardsMock = jest
+      .spyOn(PluginContext, 'useOpenSearchDashboards')
+      .mockReturnValue({
+        services: {
+          uiSettings: {
+            get: () => 'MMM D, yyyy @ HH:mm:ss',
+          },
+        },
+      });
+
+    render(<UiSettingDateFormatTime time={1682676759143} />);
+    expect(screen.getByText('Apr 28, 2023 @ 10:12:39')).toBeInTheDocument();
+
+    opensearchDashboardsMock.mockRestore();
+  });
+
+  it('should render consistent time text based default time format', () => {
+    render(<UiSettingDateFormatTime time={1682676759143} />);
+    expect(screen.getByText('Apr 28, 2023 @ 10:12:39.143')).toBeInTheDocument();
+  });
+});

--- a/public/components/common/index.ts
+++ b/public/components/common/index.ts
@@ -12,3 +12,4 @@ export * from './tag_filter';
 export * from './options_filter';
 export * from './forms';
 export * from './tag_key';
+export * from './ui_setting_date_format_time';

--- a/public/components/common/ui_setting_date_format_time.tsx
+++ b/public/components/common/ui_setting_date_format_time.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+
+import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
+import { DATE_FORMAT } from '../../../common';
+import { renderTime } from '../../utils';
+
+export const UiSettingDateFormatTime = ({ time }: { time: number | undefined }) => {
+  const {
+    services: { uiSettings },
+  } = useOpenSearchDashboards();
+  const dateFormat = uiSettings?.get('dateFormat');
+
+  return <>{time ? renderTime(time, dateFormat || DATE_FORMAT) : '-'}</>;
+};

--- a/public/components/model/__tests__/model_overview_card.test.tsx
+++ b/public/components/model/__tests__/model_overview_card.test.tsx
@@ -8,33 +8,7 @@ import React from 'react';
 import { render, screen, within } from '../../../../test/test_utils';
 import { ModelOverviewCard } from '../model_overview_card';
 
-import * as PluginContext from '../../../../../../src/plugins/opensearch_dashboards_react/public';
-
-// Cannot spyOn(PluginContext, 'useOpenSearchDashboards') directly as it results in error:
-// TypeError: Cannot redefine property: useOpenSearchDashboards
-// So we have to mock the entire module first as a workaround
-jest.mock('../../../../../../src/plugins/opensearch_dashboards_react/public', () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual('../../../../../../src/plugins/opensearch_dashboards_react/public'),
-  };
-});
-
 describe('<ModelOverviewCard />', () => {
-  beforeAll(() => {
-    jest.spyOn(PluginContext, 'useOpenSearchDashboards').mockReturnValue({
-      services: {
-        uiSettings: {
-          get: () => 'MMM D, YYYY @ HH:mm:ss.SSS',
-        },
-      },
-    });
-  });
-
-  afterAll(() => {
-    jest.spyOn(PluginContext, 'useOpenSearchDashboards').mockRestore();
-  });
-
   it('should model overview information according passed data', () => {
     render(
       <ModelOverviewCard

--- a/public/components/model/model_overview_card.tsx
+++ b/public/components/model/model_overview_card.tsx
@@ -5,9 +5,7 @@
 
 import { EuiDescriptionList, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer } from '@elastic/eui';
 import React from 'react';
-import { CopyableText } from '../common';
-import { renderTime } from '../../utils';
-import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
+import { CopyableText, UiSettingDateFormatTime } from '../common';
 
 interface ModelOverviewCardProps {
   id: string;
@@ -26,11 +24,6 @@ export const ModelOverviewCard = ({
   description,
   isModelOwner,
 }: ModelOverviewCardProps) => {
-  const {
-    services: { uiSettings },
-  } = useOpenSearchDashboards();
-  const dateFormat = uiSettings?.get('dateFormat');
-
   return (
     <EuiPanel data-test-subj="model-group-overview-card">
       <EuiSpacer size="m" />
@@ -60,7 +53,7 @@ export const ModelOverviewCard = ({
             listItems={[
               {
                 title: 'Created',
-                description: dateFormat ? renderTime(createdTime, dateFormat) : '-',
+                description: <UiSettingDateFormatTime time={createdTime} />,
               },
             ]}
           />
@@ -70,7 +63,7 @@ export const ModelOverviewCard = ({
             listItems={[
               {
                 title: 'Last updated',
-                description: dateFormat ? renderTime(updatedTime, dateFormat) : '-',
+                description: <UiSettingDateFormatTime time={updatedTime} />,
               },
             ]}
           />

--- a/public/components/model/model_overview_card.tsx
+++ b/public/components/model/model_overview_card.tsx
@@ -7,6 +7,7 @@ import { EuiDescriptionList, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer } fr
 import React from 'react';
 import { CopyableText } from '../common';
 import { renderTime } from '../../utils';
+import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 
 interface ModelOverviewCardProps {
   id: string;
@@ -25,6 +26,11 @@ export const ModelOverviewCard = ({
   description,
   isModelOwner,
 }: ModelOverviewCardProps) => {
+  const {
+    services: { uiSettings },
+  } = useOpenSearchDashboards();
+  const dateFormat = uiSettings?.get('dateFormat');
+
   return (
     <EuiPanel data-test-subj="model-group-overview-card">
       <EuiSpacer size="m" />
@@ -54,7 +60,7 @@ export const ModelOverviewCard = ({
             listItems={[
               {
                 title: 'Created',
-                description: renderTime(createdTime, 'MMM D, YYYY h:m A'),
+                description: dateFormat ? renderTime(createdTime, dateFormat) : '-',
               },
             ]}
           />
@@ -64,7 +70,7 @@ export const ModelOverviewCard = ({
             listItems={[
               {
                 title: 'Last updated',
-                description: renderTime(updatedTime, 'MMM D, YYYY h:m A'),
+                description: dateFormat ? renderTime(updatedTime, dateFormat) : '-',
               },
             ]}
           />

--- a/public/components/model/model_versions_panel/__tests__/model_version_cell.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_version_cell.test.tsx
@@ -9,6 +9,18 @@ import { render, screen } from '../../../../../test/test_utils';
 import { ModelVersionCell } from '../model_version_cell';
 import { MODEL_STATE } from '../../../../../common';
 
+import * as PluginContext from '../../../../../../../src/plugins/opensearch_dashboards_react/public';
+
+// Cannot spyOn(PluginContext, 'useOpenSearchDashboards') directly as it results in error:
+// TypeError: Cannot redefine property: useOpenSearchDashboards
+// So we have to mock the entire module first as a workaround
+jest.mock('../../../../../../../src/plugins/opensearch_dashboards_react/public', () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual('../../../../../../../src/plugins/opensearch_dashboards_react/public'),
+  };
+});
+
 const setup = (options: { columnId: string; isDetails?: boolean }) =>
   render(
     <ModelVersionCell
@@ -96,11 +108,21 @@ describe('<ModelVersionCell />', () => {
   });
 
   it('should render consistent last updated', () => {
+    const useOpenSearchDashboardsMock = jest
+      .spyOn(PluginContext, 'useOpenSearchDashboards')
+      .mockReturnValue({
+        services: {
+          uiSettings: {
+            get: () => 'MMM D, yyyy @ HH:mm:ss.SSS',
+          },
+        },
+      });
     setup({
       columnId: 'lastUpdatedTime',
     });
 
-    expect(screen.getByText('Apr 27, 2023 2:15 PM')).toBeInTheDocument();
+    expect(screen.getByText('Apr 27, 2023 @ 14:15:57.236')).toBeInTheDocument();
+    useOpenSearchDashboardsMock.mockRestore();
   });
 
   it('should render "model-1" for name column', () => {

--- a/public/components/model/model_versions_panel/__tests__/model_version_cell.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_version_cell.test.tsx
@@ -104,7 +104,6 @@ describe('<ModelVersionCell />', () => {
     });
 
     expect(screen.getByText('In progress...')).toBeInTheDocument();
-    expect(screen.getByText('Upload initiated on:')).toBeInTheDocument();
   });
 
   it('should render consistent last updated', () => {

--- a/public/components/model/model_versions_panel/__tests__/model_version_cell.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_version_cell.test.tsx
@@ -18,7 +18,7 @@ const setup = (options: { columnId: string; isDetails?: boolean }) =>
         version: '1.0.0',
         state: MODEL_STATE.uploading,
         tags: {},
-        lastUpdated: 1682604957236,
+        lastUpdatedTime: 1682604957236,
         createdTime: 1682604957236,
       }}
       isDetails={false}
@@ -50,7 +50,7 @@ describe('<ModelVersionCell />', () => {
           version: '1.0.0',
           state: MODEL_STATE.loaded,
           tags: {},
-          lastUpdated: 1682604957236,
+          lastUpdatedTime: 1682604957236,
           createdTime: 1682604957236,
         }}
         isDetails={false}
@@ -67,7 +67,7 @@ describe('<ModelVersionCell />', () => {
           version: '1.0.0',
           state: MODEL_STATE.partiallyLoaded,
           tags: {},
-          lastUpdated: 1682604957236,
+          lastUpdatedTime: 1682604957236,
           createdTime: 1682604957236,
         }}
         isDetails={false}
@@ -97,7 +97,7 @@ describe('<ModelVersionCell />', () => {
 
   it('should render consistent last updated', () => {
     setup({
-      columnId: 'lastUpdated',
+      columnId: 'lastUpdatedTime',
     });
 
     expect(screen.getByText('Apr 27, 2023 2:15 PM')).toBeInTheDocument();

--- a/public/components/model/model_versions_panel/__tests__/model_version_cell.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_version_cell.test.tsx
@@ -9,18 +9,6 @@ import { render, screen } from '../../../../../test/test_utils';
 import { ModelVersionCell } from '../model_version_cell';
 import { MODEL_STATE } from '../../../../../common';
 
-import * as PluginContext from '../../../../../../../src/plugins/opensearch_dashboards_react/public';
-
-// Cannot spyOn(PluginContext, 'useOpenSearchDashboards') directly as it results in error:
-// TypeError: Cannot redefine property: useOpenSearchDashboards
-// So we have to mock the entire module first as a workaround
-jest.mock('../../../../../../../src/plugins/opensearch_dashboards_react/public', () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual('../../../../../../../src/plugins/opensearch_dashboards_react/public'),
-  };
-});
-
 const setup = (options: { columnId: string; isDetails?: boolean }) =>
   render(
     <ModelVersionCell
@@ -107,21 +95,11 @@ describe('<ModelVersionCell />', () => {
   });
 
   it('should render consistent last updated', () => {
-    const useOpenSearchDashboardsMock = jest
-      .spyOn(PluginContext, 'useOpenSearchDashboards')
-      .mockReturnValue({
-        services: {
-          uiSettings: {
-            get: () => 'MMM D, yyyy @ HH:mm:ss.SSS',
-          },
-        },
-      });
     setup({
       columnId: 'lastUpdatedTime',
     });
 
     expect(screen.getByText('Apr 27, 2023 @ 14:15:57.236')).toBeInTheDocument();
-    useOpenSearchDashboardsMock.mockRestore();
   });
 
   it('should render "model-1" for name column', () => {

--- a/public/components/model/model_versions_panel/__tests__/model_version_list_filter.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_version_list_filter.test.tsx
@@ -124,4 +124,64 @@ describe('<ModelVersionListFilter />', () => {
     },
     10 * 1000
   );
+
+  it('should call onChangeMock with search text after search text typed', async () => {
+    jest.useFakeTimers();
+    const onChangeMock = jest.fn();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(
+      <ModelVersionListFilter
+        value={{
+          tag: [],
+          state: [],
+          status: [],
+        }}
+        onChange={onChangeMock}
+      />
+    );
+
+    expect(onChangeMock).not.toHaveBeenCalled();
+
+    await user.type(
+      screen.getByPlaceholderText('Search by version number, or keyword'),
+      'search text'
+    );
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(onChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: 'search text',
+      })
+    );
+
+    jest.useRealTimers();
+  });
+
+  it('should bind searchInput and able to clear search text by searchInputRef', async () => {
+    const onChangeMock = jest.fn();
+    let searchInput: HTMLInputElement | null = null;
+
+    render(
+      <ModelVersionListFilter
+        value={{
+          tag: [],
+          state: [],
+          status: [],
+        }}
+        onChange={onChangeMock}
+        searchInputRef={(input: HTMLInputElement | null) => {
+          searchInput = input;
+        }}
+      />
+    );
+    expect(searchInput).not.toBeNull();
+
+    const searchTextInput = screen.getByPlaceholderText('Search by version number, or keyword');
+    await userEvent.type(searchTextInput, 'search text');
+
+    expect(searchTextInput).toHaveValue('search text');
+    searchInput!.value = '';
+    expect(searchTextInput).toHaveValue('');
+  });
 });

--- a/public/components/model/model_versions_panel/__tests__/model_version_status_detail.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_version_status_detail.test.tsx
@@ -37,7 +37,7 @@ describe('<ModelVersionStatusDetail />', () => {
     jest.spyOn(PluginContext, 'useOpenSearchDashboards').mockRestore();
   });
 
-  it('should render "In progress...", uploading tip and upload initialized time ', async () => {
+  it('should render "In progress..." and uploading tip', async () => {
     render(
       <ModelVersionStatusDetail
         id="1"
@@ -54,8 +54,28 @@ describe('<ModelVersionStatusDetail />', () => {
       'href',
       '/model-registry/model-version/1'
     );
+  });
 
-    expect(screen.getByText('Upload initiated on:')).toBeInTheDocument();
+  it('should render "Success", deployment tip and deployed time ', async () => {
+    render(
+      <ModelVersionStatusDetail
+        id="1"
+        name="model-1"
+        version="1"
+        state={MODEL_STATE.loaded}
+        createdTime={1683276773541}
+        lastDeployedTime={1683276773541}
+      />
+    );
+
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByText(/.*deployed./)).toBeInTheDocument();
+    expect(screen.getByText('model-1 version 1')).toHaveAttribute(
+      'href',
+      '/model-registry/model-version/1'
+    );
+
+    expect(screen.getByText('Deployed on:')).toBeInTheDocument();
     expect(screen.getByText('May 5, 2023 @ 08:52:53.541')).toBeInTheDocument();
   });
 
@@ -81,6 +101,7 @@ describe('<ModelVersionStatusDetail />', () => {
         version="1.0.0"
         state={MODEL_STATE.loadFailed}
         createdTime={1683276773541}
+        lastDeployedTime={1683276773541}
       />
     );
 

--- a/public/components/model/model_versions_panel/__tests__/model_version_status_detail.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_version_status_detail.test.tsx
@@ -10,7 +10,33 @@ import { render, screen, waitFor } from '../../../../../test/test_utils';
 import { ModelVersionStatusDetail } from '../model_version_status_detail';
 import { MODEL_STATE } from '../../../../../common';
 
+import * as PluginContext from '../../../../../../../src/plugins/opensearch_dashboards_react/public';
+
+// Cannot spyOn(PluginContext, 'useOpenSearchDashboards') directly as it results in error:
+// TypeError: Cannot redefine property: useOpenSearchDashboards
+// So we have to mock the entire module first as a workaround
+jest.mock('../../../../../../../src/plugins/opensearch_dashboards_react/public', () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual('../../../../../../../src/plugins/opensearch_dashboards_react/public'),
+  };
+});
+
 describe('<ModelVersionStatusDetail />', () => {
+  beforeAll(() => {
+    jest.spyOn(PluginContext, 'useOpenSearchDashboards').mockReturnValue({
+      services: {
+        uiSettings: {
+          get: () => 'MMM D, yyyy @ HH:mm:ss.SSS',
+        },
+      },
+    });
+  });
+
+  afterAll(() => {
+    jest.spyOn(PluginContext, 'useOpenSearchDashboards').mockRestore();
+  });
+
   it('should render "In progress...", uploading tip and upload initialized time ', async () => {
     render(
       <ModelVersionStatusDetail

--- a/public/components/model/model_versions_panel/__tests__/model_version_status_detail.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_version_status_detail.test.tsx
@@ -10,33 +10,7 @@ import { render, screen, waitFor } from '../../../../../test/test_utils';
 import { ModelVersionStatusDetail } from '../model_version_status_detail';
 import { MODEL_STATE } from '../../../../../common';
 
-import * as PluginContext from '../../../../../../../src/plugins/opensearch_dashboards_react/public';
-
-// Cannot spyOn(PluginContext, 'useOpenSearchDashboards') directly as it results in error:
-// TypeError: Cannot redefine property: useOpenSearchDashboards
-// So we have to mock the entire module first as a workaround
-jest.mock('../../../../../../../src/plugins/opensearch_dashboards_react/public', () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual('../../../../../../../src/plugins/opensearch_dashboards_react/public'),
-  };
-});
-
 describe('<ModelVersionStatusDetail />', () => {
-  beforeAll(() => {
-    jest.spyOn(PluginContext, 'useOpenSearchDashboards').mockReturnValue({
-      services: {
-        uiSettings: {
-          get: () => 'MMM D, yyyy @ HH:mm:ss.SSS',
-        },
-      },
-    });
-  });
-
-  afterAll(() => {
-    jest.spyOn(PluginContext, 'useOpenSearchDashboards').mockRestore();
-  });
-
   it('should render "In progress..." and uploading tip', async () => {
     render(
       <ModelVersionStatusDetail

--- a/public/components/model/model_versions_panel/__tests__/model_version_table.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_version_table.test.tsx
@@ -18,7 +18,7 @@ const versions = [
     version: '1.0.0',
     state: MODEL_STATE.uploading,
     tags: { 'Accuracy: test': 0.98, 'Accuracy: train': 0.99 },
-    lastUpdated: 1682676759143,
+    lastUpdatedTime: 1682676759143,
     createdTime: 1682676759143,
   },
 ];
@@ -31,7 +31,7 @@ describe('<ModelVersionTable />', () => {
       expect(screen.getByTestId('dataGridHeaderCell-version')).toBeInTheDocument();
       expect(screen.getByTestId('dataGridHeaderCell-state')).toBeInTheDocument();
       expect(screen.getByTestId('dataGridHeaderCell-status')).toBeInTheDocument();
-      expect(screen.getByTestId('dataGridHeaderCell-lastUpdated')).toBeInTheDocument();
+      expect(screen.getByTestId('dataGridHeaderCell-lastUpdatedTime')).toBeInTheDocument();
       expect(screen.getByTestId('dataGridHeaderCell-tags.Accuracy: test')).toBeInTheDocument();
       expect(screen.getByTestId('dataGridHeaderCell-tags.Accuracy: train')).toBeInTheDocument();
     });

--- a/public/components/model/model_versions_panel/__tests__/model_version_table.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_version_table.test.tsx
@@ -11,18 +11,6 @@ import { render, screen, waitFor } from '../../../../../test/test_utils';
 import { ModelVersionTable } from '../model_version_table';
 import { MODEL_STATE } from '../../../../../common';
 
-import * as PluginContext from '../../../../../../../src/plugins/opensearch_dashboards_react/public';
-
-// Cannot spyOn(PluginContext, 'useOpenSearchDashboards') directly as it results in error:
-// TypeError: Cannot redefine property: useOpenSearchDashboards
-// So we have to mock the entire module first as a workaround
-jest.mock('../../../../../../../src/plugins/opensearch_dashboards_react/public', () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual('../../../../../../../src/plugins/opensearch_dashboards_react/public'),
-  };
-});
-
 const versions = [
   {
     id: '1',
@@ -36,19 +24,6 @@ const versions = [
 ];
 
 describe('<ModelVersionTable />', () => {
-  beforeAll(() => {
-    jest.spyOn(PluginContext, 'useOpenSearchDashboards').mockReturnValue({
-      services: {
-        uiSettings: {
-          get: () => 'MMM D, yyyy @ HH:mm:ss.SSS',
-        },
-      },
-    });
-  });
-
-  afterAll(() => {
-    jest.spyOn(PluginContext, 'useOpenSearchDashboards').mockRestore();
-  });
   it('should render consistent columns header and hide id, tags columns by default', async () => {
     render(
       <ModelVersionTable versions={[]} tags={['Accuracy: test', 'Accuracy: train', 'F1', 'F2']} />

--- a/public/components/model/model_versions_panel/__tests__/model_version_table.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_version_table.test.tsx
@@ -49,8 +49,10 @@ describe('<ModelVersionTable />', () => {
   afterAll(() => {
     jest.spyOn(PluginContext, 'useOpenSearchDashboards').mockRestore();
   });
-  it('should render consistent columns header ', async () => {
-    render(<ModelVersionTable versions={[]} tags={['Accuracy: test', 'Accuracy: train']} />);
+  it('should render consistent columns header and hide id, tags columns by default', async () => {
+    render(
+      <ModelVersionTable versions={[]} tags={['Accuracy: test', 'Accuracy: train', 'F1', 'F2']} />
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('dataGridHeaderCell-version')).toBeInTheDocument();
@@ -59,6 +61,9 @@ describe('<ModelVersionTable />', () => {
       expect(screen.getByTestId('dataGridHeaderCell-lastUpdatedTime')).toBeInTheDocument();
       expect(screen.getByTestId('dataGridHeaderCell-tags.Accuracy: test')).toBeInTheDocument();
       expect(screen.getByTestId('dataGridHeaderCell-tags.Accuracy: train')).toBeInTheDocument();
+      expect(screen.getByTestId('dataGridHeaderCell-tags.F1')).toBeInTheDocument();
+      expect(screen.queryByTestId('dataGridHeaderCell-id')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('dataGridHeaderCell-tags.F2')).not.toBeInTheDocument();
     });
   });
 

--- a/public/components/model/model_versions_panel/__tests__/model_versions_panel.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_versions_panel.test.tsx
@@ -258,6 +258,6 @@ describe('<ModelVersionsPanel />', () => {
 
       searchMock.mockRestore();
     },
-    10 * 1000
+    20 * 1000
   );
 });

--- a/public/components/model/model_versions_panel/__tests__/model_versions_panel.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_versions_panel.test.tsx
@@ -232,7 +232,7 @@ describe('<ModelVersionsPanel />', () => {
     async () => {
       render(<ModelVersionsPanel groupId="1" />);
       await waitFor(() => {
-        expect(screen.queryByText('Loading versions')).not.toBeInTheDocument();
+        expect(screen.getByTestId('dataGridHeaderCell-version')).toBeInTheDocument();
       });
       const searchMock = jest.spyOn(Model.prototype, 'search');
 

--- a/public/components/model/model_versions_panel/__tests__/model_versions_panel.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_versions_panel.test.tsx
@@ -9,6 +9,14 @@ import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor, within } from '../../../../../test/test_utils';
 import { Model } from '../../../../apis/model';
 import { ModelVersionsPanel } from '../model_versions_panel';
+import * as PluginContext from '../../../../../../../src/plugins/opensearch_dashboards_react/public';
+
+jest.mock('../../../../../../../src/plugins/opensearch_dashboards_react/public', () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual('../../../../../../../src/plugins/opensearch_dashboards_react/public'),
+  };
+});
 
 describe('<ModelVersionsPanel />', () => {
   it(
@@ -47,7 +55,12 @@ describe('<ModelVersionsPanel />', () => {
   it(
     'should call model search API again after refresh button clicked',
     async () => {
-      const searchMock = jest.spyOn(Model.prototype, 'search');
+      const searchMock = jest.spyOn(Model.prototype, 'search').mockImplementation(async () => {
+        return {
+          data: [],
+          total_models: 0,
+        };
+      });
 
       render(<ModelVersionsPanel groupId="1" />);
 
@@ -74,6 +87,8 @@ describe('<ModelVersionsPanel />', () => {
       await waitFor(() => {
         expect(searchMock).toHaveBeenLastCalledWith(
           expect.objectContaining({
+            from: 0,
+            size: 25,
             states: ['DEPLOYED', 'PARTIALLY_DEPLOYED'],
           })
         );
@@ -92,5 +107,123 @@ describe('<ModelVersionsPanel />', () => {
       searchMock.mockRestore();
     },
     10 * 10000
+  );
+
+  it('should render loading screen when calling model search API', async () => {
+    const searchMock = jest
+      .spyOn(Model.prototype, 'search')
+      .mockImplementation(() => new Promise(() => {}));
+    render(<ModelVersionsPanel groupId="1" />);
+
+    expect(screen.getByText('Loading versions')).toBeInTheDocument();
+
+    searchMock.mockRestore();
+  });
+
+  it('should render error screen and show error toast after call model search failed', async () => {
+    const searchMock = jest.spyOn(Model.prototype, 'search').mockImplementation(async () => {
+      throw new Error();
+    });
+    const dangerMock = jest.fn();
+    const pluginMock = jest.spyOn(PluginContext, 'useOpenSearchDashboards').mockReturnValue({
+      notifications: {
+        toasts: {
+          danger: dangerMock,
+        },
+      },
+    });
+    render(<ModelVersionsPanel groupId="1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load versions')).toBeInTheDocument();
+      expect(dangerMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Failed to load data',
+        })
+      );
+    });
+
+    searchMock.mockRestore();
+    pluginMock.mockRestore();
+  });
+
+  it('should render empty screen if model no versions', async () => {
+    const searchMock = jest.spyOn(Model.prototype, 'search').mockImplementation(async () => {
+      return {
+        data: [],
+        total_models: 0,
+      };
+    });
+
+    render(<ModelVersionsPanel groupId="1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Registered versions will appear here.')).toBeInTheDocument();
+      expect(screen.getByText('Register new version')).toBeInTheDocument();
+      expect(screen.getByText('Register new version').closest('a')).toHaveAttribute(
+        'href',
+        '/model-registry/register-model/1'
+      );
+      expect(screen.getByText('Read documentation')).toBeInTheDocument();
+    });
+
+    searchMock.mockRestore();
+  });
+
+  it('should render no-result screen and reset search button if no result for specific condition', async () => {
+    render(<ModelVersionsPanel groupId="1" />);
+    await waitFor(() => {
+      expect(screen.getByTitle('Status')).toBeInTheDocument();
+    });
+
+    const searchMock = jest.spyOn(Model.prototype, 'search').mockImplementation(async () => {
+      return {
+        data: [],
+        total_models: 0,
+      };
+    });
+    await userEvent.click(screen.getByTitle('Status'));
+    await userEvent.click(screen.getByRole('option', { name: 'In progress...' }));
+
+    expect(
+      screen.getByText(
+        'There are no results for your search. Reset the search criteria to view registered versions.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText('Reset search criteria')).toBeInTheDocument();
+
+    searchMock.mockRestore();
+  });
+
+  it(
+    'should call model search without filter condition after reset button clicked',
+    async () => {
+      render(<ModelVersionsPanel groupId="1" />);
+      await waitFor(() => {
+        expect(screen.getByTitle('Status')).toBeInTheDocument();
+      });
+
+      const searchMock = jest.spyOn(Model.prototype, 'search').mockImplementation(async () => {
+        return {
+          data: [],
+          total_models: 0,
+        };
+      });
+      await userEvent.click(screen.getByTitle('Status'));
+      await userEvent.click(screen.getByRole('option', { name: 'In progress...' }));
+
+      expect(searchMock).toHaveBeenCalledTimes(1);
+      await userEvent.click(screen.getByText('Reset search criteria'));
+      expect(searchMock).toHaveBeenCalledTimes(2);
+      expect(searchMock).toHaveBeenCalledWith({
+        from: 0,
+        size: 25,
+        // TODO: Change to model group id once parameter added
+        ids: expect.any(Array),
+      });
+
+      searchMock.mockRestore();
+    },
+    10 * 1000
   );
 });

--- a/public/components/model/model_versions_panel/__tests__/model_versions_panel.test.tsx
+++ b/public/components/model/model_versions_panel/__tests__/model_versions_panel.test.tsx
@@ -226,4 +226,38 @@ describe('<ModelVersionsPanel />', () => {
     },
     10 * 1000
   );
+
+  it(
+    'should only sort by Last updated column after column sort button clicked',
+    async () => {
+      render(<ModelVersionsPanel groupId="1" />);
+      await waitFor(() => {
+        expect(screen.queryByText('Loading versions')).not.toBeInTheDocument();
+      });
+      const searchMock = jest.spyOn(Model.prototype, 'search');
+
+      await userEvent.click(
+        within(screen.getByTestId('dataGridHeaderCell-version')).getByText('Version')
+      );
+      await userEvent.click(screen.getByTitle('Sort A-Z'));
+      expect(searchMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          sort: ['version-asc'],
+        })
+      );
+
+      await userEvent.click(
+        within(screen.getByTestId('dataGridHeaderCell-lastUpdatedTime')).getByText('Last updated')
+      );
+      await userEvent.click(screen.getByTitle('Sort Z-A'));
+      expect(searchMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          sort: ['last_updated_time-desc'],
+        })
+      );
+
+      searchMock.mockRestore();
+    },
+    10 * 1000
+  );
 });

--- a/public/components/model/model_versions_panel/model_version_cell.tsx
+++ b/public/components/model/model_versions_panel/model_version_cell.tsx
@@ -10,9 +10,19 @@ import { EuiBadge, EuiText } from '@elastic/eui';
 import { renderTime } from '../../../utils/table';
 import { MODEL_STATE } from '../../../../common';
 import { VersionTableDataItem } from '../types';
+import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 
 import { ModelVersionStatusCell } from './model_version_status_cell';
 import { ModelVersionStatusDetail } from './model_version_status_detail';
+
+const ModelVersionLastUpdatedCell = ({ lastUpdatedTime }: { lastUpdatedTime: number }) => {
+  const {
+    services: { uiSettings },
+  } = useOpenSearchDashboards();
+  const dateFormat = uiSettings?.get('dateFormat');
+
+  return <>{dateFormat ? renderTime(lastUpdatedTime, dateFormat) : '-'}</>;
+};
 
 interface ModelVersionCellProps {
   columnId: string;
@@ -51,7 +61,7 @@ export const ModelVersionCell = ({ data, columnId, isDetails }: ModelVersionCell
       );
     }
     case 'lastUpdatedTime':
-      return renderTime(data.lastUpdatedTime, 'MMM D, YYYY h:m A');
+      return <ModelVersionLastUpdatedCell lastUpdatedTime={data.lastUpdatedTime} />;
     default:
       return get(data, columnId, '-');
   }

--- a/public/components/model/model_versions_panel/model_version_cell.tsx
+++ b/public/components/model/model_versions_panel/model_version_cell.tsx
@@ -7,22 +7,12 @@ import React from 'react';
 import { get } from 'lodash';
 import { EuiBadge, EuiText } from '@elastic/eui';
 
-import { renderTime } from '../../../utils/table';
 import { MODEL_STATE } from '../../../../common';
 import { VersionTableDataItem } from '../types';
-import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
+import { UiSettingDateFormatTime } from '../../common';
 
 import { ModelVersionStatusCell } from './model_version_status_cell';
 import { ModelVersionStatusDetail } from './model_version_status_detail';
-
-const ModelVersionLastUpdatedCell = ({ lastUpdatedTime }: { lastUpdatedTime: number }) => {
-  const {
-    services: { uiSettings },
-  } = useOpenSearchDashboards();
-  const dateFormat = uiSettings?.get('dateFormat');
-
-  return <>{dateFormat ? renderTime(lastUpdatedTime, dateFormat) : '-'}</>;
-};
 
 interface ModelVersionCellProps {
   columnId: string;
@@ -61,7 +51,7 @@ export const ModelVersionCell = ({ data, columnId, isDetails }: ModelVersionCell
       );
     }
     case 'lastUpdatedTime':
-      return <ModelVersionLastUpdatedCell lastUpdatedTime={data.lastUpdatedTime} />;
+      return <UiSettingDateFormatTime time={data.lastUpdatedTime} />;
     default:
       return get(data, columnId, '-');
   }

--- a/public/components/model/model_versions_panel/model_version_cell.tsx
+++ b/public/components/model/model_versions_panel/model_version_cell.tsx
@@ -29,6 +29,9 @@ export const ModelVersionCell = ({ data, columnId, isDetails }: ModelVersionCell
         version={data.version}
         state={data.state}
         createdTime={data.createdTime}
+        lastRegisteredTime={data.lastRegisteredTime}
+        lastDeployedTime={data.lastDeployedTime}
+        lastUndeployedTime={data.lastUndeployedTime}
       />
     );
   }

--- a/public/components/model/model_versions_panel/model_version_cell.tsx
+++ b/public/components/model/model_versions_panel/model_version_cell.tsx
@@ -47,8 +47,8 @@ export const ModelVersionCell = ({ data, columnId, isDetails }: ModelVersionCell
         </EuiBadge>
       );
     }
-    case 'lastUpdated':
-      return renderTime(data.lastUpdated, 'MMM D, YYYY h:m A');
+    case 'lastUpdatedTime':
+      return renderTime(data.lastUpdatedTime, 'MMM D, YYYY h:m A');
     default:
       return get(data, columnId, '-');
   }

--- a/public/components/model/model_versions_panel/model_version_list_filter.tsx
+++ b/public/components/model/model_versions_panel/model_version_list_filter.tsx
@@ -13,7 +13,13 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 
-import { TagFilterValue, TagFilter, OptionsFilter, SelectedTagFiltersPanel } from '../../common';
+import {
+  TagFilterValue,
+  TagFilter,
+  OptionsFilter,
+  SelectedTagFiltersPanel,
+  DebouncedSearchBar,
+} from '../../common';
 import { useModelTagKeys } from '../../model_list/model_list.hooks';
 
 const statusOptions = [
@@ -46,14 +52,20 @@ export interface ModelVersionListFilterValue {
   status: Array<typeof statusOptions[number]['value']>;
   state: Array<typeof stateOptions[number]>;
   tag: TagFilterValue[];
+  search?: string;
 }
 
 interface ModelVersionListFilterProps {
-  value: ModelVersionListFilterValue;
+  searchInputRef?: (input: HTMLInputElement | null) => void;
+  value: Omit<ModelVersionListFilterValue, 'search'>;
   onChange: (value: ModelVersionListFilterValue) => void;
 }
 
-export const ModelVersionListFilter = ({ value, onChange }: ModelVersionListFilterProps) => {
+export const ModelVersionListFilter = ({
+  searchInputRef,
+  value,
+  onChange,
+}: ModelVersionListFilterProps) => {
   // TODO: Change to model tags API and pass model group id here
   const [tagKeysLoading, tagKeys] = useModelTagKeys();
   const valueRef = useRef(value);
@@ -80,11 +92,22 @@ export const ModelVersionListFilter = ({ value, onChange }: ModelVersionListFilt
     [onChange]
   );
 
+  const handleSearch = useCallback(
+    (search: string) => {
+      onChange({ ...valueRef.current, search });
+    },
+    [onChange]
+  );
+
   return (
     <>
       <EuiFlexGroup gutterSize="m">
         <EuiFlexItem>
-          <EuiFieldSearch placeholder="Search by version number, or keyword" fullWidth />
+          <DebouncedSearchBar
+            placeholder="Search by version number, or keyword"
+            onSearch={handleSearch}
+            inputRef={searchInputRef}
+          />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiFilterGroup>

--- a/public/components/model/model_versions_panel/model_version_status_detail.tsx
+++ b/public/components/model/model_versions_panel/model_version_status_detail.tsx
@@ -26,7 +26,7 @@ export const state2DetailContentMap: {
     title: string;
     description: (versionLink: React.ReactNode) => React.ReactNode;
     timeTitle: string;
-    timeField: 'createdTime';
+    timeField: 'createdTime' | 'lastRegisteredTime' | 'lastDeployedTime' | 'lastUndeployedTime';
   };
 } = {
   [MODEL_STATE.uploading]: {
@@ -51,25 +51,25 @@ export const state2DetailContentMap: {
       <>The model artifact for {versionLink} uploaded.</>
     ),
     timeTitle: 'Uploaded on',
-    timeField: 'createdTime',
+    timeField: 'lastRegisteredTime',
   },
   [MODEL_STATE.loaded]: {
     title: 'Success',
     description: (versionLink: React.ReactNode) => <>{versionLink} deployed.</>,
     timeTitle: 'Deployed on',
-    timeField: 'createdTime',
+    timeField: 'lastDeployedTime',
   },
   [MODEL_STATE.unloaded]: {
     title: 'Success',
     description: (versionLink: React.ReactNode) => <>{versionLink} undeployed.</>,
     timeTitle: 'Undeployed on',
-    timeField: 'createdTime',
+    timeField: 'lastUndeployedTime',
   },
   [MODEL_STATE.loadFailed]: {
     title: 'Error',
     description: (versionLink: React.ReactNode) => <>{versionLink} deployment failed.</>,
     timeTitle: 'Deployment failed on',
-    timeField: 'createdTime',
+    timeField: 'lastDeployedTime',
   },
   [MODEL_STATE.registerFailed]: {
     title: 'Error',
@@ -99,6 +99,9 @@ export const ModelVersionStatusDetail = ({
   name: string;
   version: string;
   createdTime: number;
+  lastRegisteredTime?: number;
+  lastDeployedTime?: number;
+  lastUndeployedTime?: number;
 }) => {
   const [isErrorDetailsModalShowed, setIsErrorDetailsModalShowed] = useState(false);
   const [isLoadingErrorDetails, setIsLoadingErrorDetails] = useState(false);
@@ -143,6 +146,7 @@ export const ModelVersionStatusDetail = ({
     return <>-</>;
   }
   const { title, description, timeTitle, timeField } = statusContent;
+  const timeValue = restProps[timeField];
 
   return (
     <>
@@ -163,7 +167,7 @@ export const ModelVersionStatusDetail = ({
           </EuiText>
           <EuiSpacer size="s" />
           <EuiText>
-            <b>{timeTitle}:</b> {renderTime(restProps[timeField], DATE_FORMAT)}
+            <b>{timeTitle}:</b> {timeValue ? renderTime(timeValue, DATE_FORMAT) : '-'}
           </EuiText>
           {(state === MODEL_STATE.loadFailed || state === MODEL_STATE.registerFailed) && (
             <>

--- a/public/components/model/model_versions_panel/model_version_status_detail.tsx
+++ b/public/components/model/model_versions_panel/model_version_status_detail.tsx
@@ -14,9 +14,10 @@ import {
 } from '@elastic/eui';
 
 import { Link, generatePath } from 'react-router-dom';
-import { DATE_FORMAT, MODEL_STATE, routerPaths } from '../../../../common';
+import { MODEL_STATE, routerPaths } from '../../../../common';
 import { APIProvider } from '../../../apis/api_provider';
 import { renderTime } from '../../../utils';
+import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 
 import { ModelVersionErrorDetailsModal } from './model_version_error_details_modal';
 
@@ -106,6 +107,10 @@ export const ModelVersionStatusDetail = ({
   const [isErrorDetailsModalShowed, setIsErrorDetailsModalShowed] = useState(false);
   const [isLoadingErrorDetails, setIsLoadingErrorDetails] = useState(false);
   const [errorDetails, setErrorDetails] = useState<string>();
+  const {
+    services: { uiSettings },
+  } = useOpenSearchDashboards();
+  const dateFormat = uiSettings?.get('dateFormat');
 
   const handleSeeFullErrorClick = useCallback(async () => {
     const state2TaskTypeMap: { [key in MODEL_STATE]?: string } = {
@@ -167,7 +172,7 @@ export const ModelVersionStatusDetail = ({
           </EuiText>
           <EuiSpacer size="s" />
           <EuiText>
-            <b>{timeTitle}:</b> {timeValue ? renderTime(timeValue, DATE_FORMAT) : '-'}
+            <b>{timeTitle}:</b> {timeValue && dateFormat ? renderTime(timeValue, dateFormat) : '-'}
           </EuiText>
           {(state === MODEL_STATE.loadFailed || state === MODEL_STATE.registerFailed) && (
             <>

--- a/public/components/model/model_versions_panel/model_version_status_detail.tsx
+++ b/public/components/model/model_versions_panel/model_version_status_detail.tsx
@@ -12,12 +12,11 @@ import {
   EuiPopoverTitle,
   EuiLink,
 } from '@elastic/eui';
-
 import { Link, generatePath } from 'react-router-dom';
+
 import { MODEL_STATE, routerPaths } from '../../../../common';
+import { UiSettingDateFormatTime } from '../../common';
 import { APIProvider } from '../../../apis/api_provider';
-import { renderTime } from '../../../utils';
-import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 
 import { ModelVersionErrorDetailsModal } from './model_version_error_details_modal';
 
@@ -103,10 +102,6 @@ export const ModelVersionStatusDetail = ({
   const [isErrorDetailsModalShowed, setIsErrorDetailsModalShowed] = useState(false);
   const [isLoadingErrorDetails, setIsLoadingErrorDetails] = useState(false);
   const [errorDetails, setErrorDetails] = useState<string>();
-  const {
-    services: { uiSettings },
-  } = useOpenSearchDashboards();
-  const dateFormat = uiSettings?.get('dateFormat');
 
   const handleSeeFullErrorClick = useCallback(async () => {
     const state2TaskTypeMap: { [key in MODEL_STATE]?: string } = {
@@ -170,8 +165,7 @@ export const ModelVersionStatusDetail = ({
             <>
               <EuiSpacer size="s" />
               <EuiText>
-                <b>{timeTitle}:</b>{' '}
-                {timeValue && dateFormat ? renderTime(timeValue, dateFormat) : '-'}
+                <b>{timeTitle}:</b> <UiSettingDateFormatTime time={timeValue} />
               </EuiText>
             </>
           )}

--- a/public/components/model/model_versions_panel/model_version_status_detail.tsx
+++ b/public/components/model/model_versions_panel/model_version_status_detail.tsx
@@ -26,8 +26,8 @@ export const state2DetailContentMap: {
   [key in MODEL_STATE]?: {
     title: string;
     description: (versionLink: React.ReactNode) => React.ReactNode;
-    timeTitle: string;
-    timeField: 'createdTime' | 'lastRegisteredTime' | 'lastDeployedTime' | 'lastUndeployedTime';
+    timeTitle?: string;
+    timeField?: 'createdTime' | 'lastRegisteredTime' | 'lastDeployedTime' | 'lastUndeployedTime';
   };
 } = {
   [MODEL_STATE.uploading]: {
@@ -35,16 +35,12 @@ export const state2DetailContentMap: {
     description: (versionLink: React.ReactNode) => (
       <>The model artifact for {versionLink} is uploading.</>
     ),
-    timeTitle: 'Upload initiated on',
-    timeField: 'createdTime',
   },
   [MODEL_STATE.loading]: {
     title: 'In progress...',
     description: (versionLink: React.ReactNode) => (
       <>The model artifact for {versionLink} is deploying.</>
     ),
-    timeTitle: 'Deployment initiated on',
-    timeField: 'createdTime',
   },
   [MODEL_STATE.uploaded]: {
     title: 'Success',
@@ -151,7 +147,7 @@ export const ModelVersionStatusDetail = ({
     return <>-</>;
   }
   const { title, description, timeTitle, timeField } = statusContent;
-  const timeValue = restProps[timeField];
+  const timeValue = timeField ? restProps[timeField] : undefined;
 
   return (
     <>
@@ -170,10 +166,15 @@ export const ModelVersionStatusDetail = ({
               </Link>
             )}
           </EuiText>
-          <EuiSpacer size="s" />
-          <EuiText>
-            <b>{timeTitle}:</b> {timeValue && dateFormat ? renderTime(timeValue, dateFormat) : '-'}
-          </EuiText>
+          {timeTitle && (
+            <>
+              <EuiSpacer size="s" />
+              <EuiText>
+                <b>{timeTitle}:</b>{' '}
+                {timeValue && dateFormat ? renderTime(timeValue, dateFormat) : '-'}
+              </EuiText>
+            </>
+          )}
           {(state === MODEL_STATE.loadFailed || state === MODEL_STATE.registerFailed) && (
             <>
               <EuiSpacer size="s" />

--- a/public/components/model/model_versions_panel/model_version_table.tsx
+++ b/public/components/model/model_versions_panel/model_version_table.tsx
@@ -70,7 +70,7 @@ export const ModelVersionTable = ({
         isSortable: false,
       },
       {
-        id: 'lastUpdated',
+        id: 'lastUpdatedTime',
         displayAsText: 'Last updated',
       },
       {

--- a/public/components/model/model_versions_panel/model_version_table.tsx
+++ b/public/components/model/model_versions_panel/model_version_table.tsx
@@ -119,9 +119,18 @@ export const ModelVersionTable = ({
     ],
     [versions]
   );
-  const [visibleColumns, setVisibleColumns] = useState(() =>
-    columns.map(({ id }) => id).filter((columnId) => columnId !== 'id')
-  );
+  const [visibleColumns, setVisibleColumns] = useState(() => {
+    const tagHiddenByDefaultColumns = tags.slice(3);
+    return columns
+      .map(({ id }) => id)
+      .filter((columnId) => {
+        if (columnId.startsWith('tags.')) {
+          const [_prefix, tag] = columnId;
+          return !tagHiddenByDefaultColumns.includes(tag);
+        }
+        return columnId !== 'id';
+      });
+  });
   const columnVisibility = useMemo(() => ({ visibleColumns, setVisibleColumns }), [visibleColumns]);
 
   const renderCellValue = useCallback(

--- a/public/components/model/model_versions_panel/model_version_table.tsx
+++ b/public/components/model/model_versions_panel/model_version_table.tsx
@@ -125,7 +125,7 @@ export const ModelVersionTable = ({
       .map(({ id }) => id)
       .filter((columnId) => {
         if (columnId.startsWith('tags.')) {
-          const [_prefix, tag] = columnId;
+          const [_prefix, tag] = columnId.split('.');
           return !tagHiddenByDefaultColumns.includes(tag);
         }
         return columnId !== 'id';

--- a/public/components/model/model_versions_panel/model_versions_panel.tsx
+++ b/public/components/model/model_versions_panel/model_versions_panel.tsx
@@ -121,6 +121,9 @@ export const ModelVersionsPanel = ({ groupId }: ModelVersionsPanelProps) => {
       // TODO: Change to use tags in model version once structure finalized
       tags: {},
       createdTime: item.created_time,
+      lastRegisteredTime: item.last_registered_time,
+      lastDeployedTime: item.last_deployed_time,
+      lastUndeployedTime: item.last_undeployed_time,
     }));
   }, [versionsData]);
 

--- a/public/components/model/model_versions_panel/model_versions_panel.tsx
+++ b/public/components/model/model_versions_panel/model_versions_panel.tsx
@@ -7,6 +7,7 @@ import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react'
 import {
   EuiButton,
   EuiButtonEmpty,
+  EuiDataGridSorting,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -73,6 +74,15 @@ const getStatesParam = ({
   });
 };
 
+const getSortParam = (sort: Array<{ id: string; direction: 'asc' | 'desc' }>) => {
+  const id2fieldMap: { [key: string]: string } = {
+    lastUpdatedTime: 'last_updated_time',
+  };
+  return sort.length > 0
+    ? sort.map(({ id, direction }) => `${id2fieldMap[id] || id}-${direction}`)
+    : undefined;
+};
+
 interface ModelVersionsPanelProps {
   groupId: string;
 }
@@ -103,6 +113,7 @@ export const ModelVersionsPanel = ({ groupId }: ModelVersionsPanelProps) => {
       size: params.pageSize,
       states: getStatesParam(params.filter),
       versionOrKeyword: params.filter.search,
+      sort: getSortParam(params.sort),
     }
   );
   const totalVersionCount = versionsData?.total_models;
@@ -144,11 +155,16 @@ export const ModelVersionsPanel = ({ groupId }: ModelVersionsPanelProps) => {
     };
   }, [params.pageIndex, params.pageSize, totalVersionCount]);
 
-  const versionsSorting = useMemo(
+  const versionsSorting = useMemo<EuiDataGridSorting>(
     () => ({
       columns: params.sort,
       onSort: (sort) => {
-        setParams((previousParams) => ({ ...previousParams, sort }));
+        setParams((previousParams) => ({
+          ...previousParams,
+          sort: sort.filter(
+            (item) => !previousParams.sort.find((previousItem) => previousItem.id === item.id)
+          ),
+        }));
       },
     }),
     [params]

--- a/public/components/model/model_versions_panel/model_versions_panel.tsx
+++ b/public/components/model/model_versions_panel/model_versions_panel.tsx
@@ -117,7 +117,7 @@ export const ModelVersionsPanel = ({ groupId }: ModelVersionsPanelProps) => {
       name: item.name,
       version: item.model_version,
       state: item.model_state,
-      lastUpdated: item.last_updated_time,
+      lastUpdatedTime: item.last_updated_time,
       // TODO: Change to use tags in model version once structure finalized
       tags: {},
       createdTime: item.created_time,

--- a/public/components/model/types.ts
+++ b/public/components/model/types.ts
@@ -14,6 +14,9 @@ export interface VersionTableDataItem {
   lastUpdatedTime: number;
   tags: { [key: string]: string | number };
   createdTime: number;
+  lastRegisteredTime?: number;
+  lastDeployedTime?: number;
+  lastUndeployedTime?: number;
 }
 
 export interface Tag {

--- a/public/components/model/types.ts
+++ b/public/components/model/types.ts
@@ -11,7 +11,7 @@ export interface VersionTableDataItem {
   name: string;
   version: string;
   state: MODEL_STATE;
-  lastUpdated: number;
+  lastUpdatedTime: number;
   tags: { [key: string]: string | number };
   createdTime: number;
 }

--- a/public/components/model_version/version_details.tsx
+++ b/public/components/model_version/version_details.tsx
@@ -15,7 +15,7 @@ import {
   EuiIcon,
 } from '@elastic/eui';
 import { renderTime } from '../../utils';
-import { DATE_FORMAT } from '../../../common/constant';
+import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 
 interface Props {
   description?: string;
@@ -30,6 +30,11 @@ export const ModelVersionDetails = ({
   lastUpdatedTime,
   modelId,
 }: Props) => {
+  const {
+    services: { uiSettings },
+  } = useOpenSearchDashboards();
+  const dateFormat = uiSettings?.get('dateFormat');
+
   return (
     <EuiPanel>
       <EuiTitle size="xs">
@@ -57,14 +62,16 @@ export const ModelVersionDetails = ({
           <EuiTitle size="xs">
             <h4>Created</h4>
           </EuiTitle>
-          <EuiText size="s">{createdTime ? renderTime(createdTime, DATE_FORMAT) : '-'}</EuiText>
+          <EuiText size="s">
+            {createdTime && dateFormat ? renderTime(createdTime, dateFormat) : '-'}
+          </EuiText>
         </EuiFlexItem>
         <EuiFlexItem style={{ maxWidth: 250 }}>
           <EuiTitle size="xs">
             <h4>Last updated</h4>
           </EuiTitle>
           <EuiText size="s">
-            {lastUpdatedTime ? renderTime(lastUpdatedTime, DATE_FORMAT) : '-'}
+            {lastUpdatedTime && dateFormat ? renderTime(lastUpdatedTime, dateFormat) : '-'}
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem style={{ maxWidth: 250 }}>

--- a/public/components/model_version/version_details.tsx
+++ b/public/components/model_version/version_details.tsx
@@ -14,8 +14,7 @@ import {
   EuiCopy,
   EuiIcon,
 } from '@elastic/eui';
-import { renderTime } from '../../utils';
-import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
+import { UiSettingDateFormatTime } from '../common';
 
 interface Props {
   description?: string;
@@ -30,11 +29,6 @@ export const ModelVersionDetails = ({
   lastUpdatedTime,
   modelId,
 }: Props) => {
-  const {
-    services: { uiSettings },
-  } = useOpenSearchDashboards();
-  const dateFormat = uiSettings?.get('dateFormat');
-
   return (
     <EuiPanel>
       <EuiTitle size="xs">
@@ -63,7 +57,7 @@ export const ModelVersionDetails = ({
             <h4>Created</h4>
           </EuiTitle>
           <EuiText size="s">
-            {createdTime && dateFormat ? renderTime(createdTime, dateFormat) : '-'}
+            <UiSettingDateFormatTime time={createdTime} />
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem style={{ maxWidth: 250 }}>
@@ -71,7 +65,7 @@ export const ModelVersionDetails = ({
             <h4>Last updated</h4>
           </EuiTitle>
           <EuiText size="s">
-            {lastUpdatedTime && dateFormat ? renderTime(lastUpdatedTime, dateFormat) : '-'}
+            <UiSettingDateFormatTime time={lastUpdatedTime} />
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem style={{ maxWidth: 250 }}>

--- a/server/routes/model_router.ts
+++ b/server/routes/model_router.ts
@@ -77,11 +77,22 @@ export const modelRouter = (services: { modelService: ModelService }, router: IR
           ),
           states: schema.maybe(schema.oneOf([schema.arrayOf(modelStateSchema), modelStateSchema])),
           nameOrId: schema.maybe(schema.string()),
+          versionOrKeyword: schema.maybe(schema.string()),
         }),
       },
     },
     async (context, request) => {
-      const { algorithms, ids, from, size, sort, name, states, nameOrId } = request.query;
+      const {
+        algorithms,
+        ids,
+        from,
+        size,
+        sort,
+        name,
+        states,
+        nameOrId,
+        versionOrKeyword,
+      } = request.query;
       try {
         const payload = await ModelService.search({
           client: context.core.opensearch.client,
@@ -93,6 +104,7 @@ export const modelRouter = (services: { modelService: ModelService }, router: IR
           name,
           states: typeof states === 'string' ? [states] : states,
           nameOrId,
+          versionOrKeyword,
         });
         return opensearchDashboardsResponseFactory.ok({ body: payload });
       } catch (err) {

--- a/server/routes/model_router.ts
+++ b/server/routes/model_router.ts
@@ -32,7 +32,8 @@ const validateSortItem = (sort: string) => {
 };
 
 const validateUniqueSort = (sort: string[]) => {
-  if (new Set(sort).size < sort.length) {
+  const uniqueSortKeys = new Set(sort.map((item) => item.split('-')[0]));
+  if (uniqueSortKeys.size < sort.length) {
     return 'Invalidate sort';
   }
   return undefined;

--- a/server/routes/model_router.ts
+++ b/server/routes/model_router.ts
@@ -17,7 +17,7 @@ import {
 
 const validateSortItem = (sort: string) => {
   const [key, direction] = sort.split('-');
-  if (typeof key !== 'string' || typeof direction !== 'string') {
+  if (key === undefined || direction === undefined) {
     return 'Invalidate sort';
   }
   if (direction !== 'asc' && direction !== 'desc') {
@@ -32,13 +32,8 @@ const validateSortItem = (sort: string) => {
 };
 
 const validateUniqueSort = (sort: string[]) => {
-  const existsSortKeyMap: { [key: string]: boolean } = {};
-  for (let i = 0; i < sort.length; i++) {
-    const [key] = sort[i].split('-');
-    if (existsSortKeyMap[key]) {
-      return 'Invalidate sort';
-    }
-    existsSortKeyMap[key] = true;
+  if (new Set(sort).size < sort.length) {
+    return 'Invalidate sort';
   }
   return undefined;
 };

--- a/server/services/model_service.ts
+++ b/server/services/model_service.ts
@@ -25,7 +25,7 @@ import {
 } from '../../../../src/core/server';
 import { MODEL_STATE, ModelSearchSort } from '../../common';
 
-import { convertModelSource, generateModelSearchQuery } from './utils/model';
+import { generateModelSearchQuery } from './utils/model';
 import { RecordNotFoundError } from './errors';
 import { MODEL_BASE_API, MODEL_META_API, MODEL_UPLOAD_API } from './utils/constants';
 
@@ -89,6 +89,7 @@ export class ModelService {
     name?: string;
     states?: MODEL_STATE[];
     nameOrId?: string;
+    versionOrKeyword?: string;
   }) {
     const {
       body: { hits },

--- a/server/services/model_service.ts
+++ b/server/services/model_service.ts
@@ -23,7 +23,7 @@ import {
   IScopedClusterClient,
   ScopeableRequest,
 } from '../../../../src/core/server';
-import { MODEL_STATE, ModelSearchSort } from '../../common';
+import { MODEL_STATE } from '../../common';
 
 import { generateModelSearchQuery } from './utils/model';
 import { RecordNotFoundError } from './errors';
@@ -85,7 +85,7 @@ export class ModelService {
     ids?: string[];
     from: number;
     size: number;
-    sort?: ModelSearchSort[];
+    sort?: string[];
     name?: string;
     states?: MODEL_STATE[];
     nameOrId?: string;

--- a/server/services/utils/model.ts
+++ b/server/services/utils/model.ts
@@ -12,12 +12,14 @@ export const generateModelSearchQuery = ({
   name,
   states,
   nameOrId,
+  versionOrKeyword,
 }: {
   ids?: string[];
   algorithms?: string[];
   name?: string;
   states?: MODEL_STATE[];
   nameOrId?: string;
+  versionOrKeyword?: string;
 }) => ({
   bool: {
     must: [
@@ -44,6 +46,24 @@ export const generateModelSearchQuery = ({
                     },
                   },
                   generateTermQuery('_id', nameOrId),
+                ],
+              },
+            },
+          ]
+        : []),
+      ...(versionOrKeyword
+        ? [
+            {
+              bool: {
+                should: [
+                  {
+                    wildcard: {
+                      model_version: {
+                        value: `*${versionOrKeyword}*`,
+                        case_insensitive: true,
+                      },
+                    },
+                  },
                 ],
               },
             },


### PR DESCRIPTION
### Description
1. Add loading / empty / no-result / failed screens
2. Add versionOrKeyword for model search
3. Update model detail version table status detail time value
4. Show only 3 tags column by default
5. Change to uiSettings time format
6. Integrate sort for model detail version table

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
