### PR TITLE
Revert remove experiment banner and enable by default

### DIFF
--- a/public/components/experiment_warning/__tests__/index.test.tsx
+++ b/public/components/experiment_warning/__tests__/index.test.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import React from 'react';
+import { render, screen } from '../../../../test/test_utils';
+import { ExperimentalWarning } from '..';
+
+describe('<ExperimentalWarning />', () => {
+  it('should navigate to # when clicking link of "Machine Learning Documentation"', () => {
+    render(<ExperimentalWarning />);
+    const link = screen.getByText('Machine Learning Documentation');
+    expect(link.getAttribute('href')).toBe(
+      'https://opensearch.org/docs/latest/ml-commons-plugin/ml-dashbaord/'
+    );
+  });
+
+  it('should navigate to # when clicking forum.opensearch.org', () => {
+    render(<ExperimentalWarning />);
+    const link = screen.getByText('forum.opensearch.org');
+    expect(link.getAttribute('href')).toBe(
+      'https://forum.opensearch.org/t/feedback-ml-commons-ml-model-health-dashboard-for-admins-experimental-release/12494'
+    );
+  });
+});

--- a/public/components/experiment_warning/index.tsx
+++ b/public/components/experiment_warning/index.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import React from 'react';
+
+import { EuiCallOut, EuiLink } from '@elastic/eui';
+
+export const ExperimentalWarning = () => {
+  return (
+    <EuiCallOut title="Experimental Feature" iconType="iInCircle">
+      The feature is experimental and should not be used in a production environment. For more
+      information, see{' '}
+      <EuiLink href="https://opensearch.org/docs/latest/ml-commons-plugin/ml-dashbaord/" external>
+        Machine Learning Documentation
+      </EuiLink>
+      . To leave feedback, visit{' '}
+      <EuiLink
+        href="https://forum.opensearch.org/t/feedback-ml-commons-ml-model-health-dashboard-for-admins-experimental-release/12494"
+        external
+      >
+        forum.opensearch.org
+      </EuiLink>
+      .
+    </EuiCallOut>
+  );
+};

--- a/public/components/monitoring/index.tsx
+++ b/public/components/monitoring/index.tsx
@@ -16,6 +16,7 @@ import React, { useState, useRef, useCallback } from 'react';
 
 import { RefreshInterval } from '../common/refresh_interval';
 import { PreviewPanel } from '../preview_panel';
+import { ExperimentalWarning } from '../experiment_warning';
 import { ModelDeploymentItem, ModelDeploymentTable } from './model_deployment_table';
 import { useMonitoring } from './use_monitoring';
 import { ModelStatusFilter } from './model_status_filter';
@@ -68,6 +69,7 @@ export const Monitoring = () => {
 
   return (
     <div>
+      <ExperimentalWarning />
       <EuiSpacer size="s" />
       <EuiSpacer size="xs" />
       <EuiPageHeader

--- a/release-notes/opensearch-ml-commons-dashboards.release-notes-2.8.0.0.md
+++ b/release-notes/opensearch-ml-commons-dashboards.release-notes-2.8.0.0.md
@@ -6,7 +6,6 @@ Compatible with OpenSearch 2.8.0
 ### Features
 
 * Remove experiment warning banner. ([#194](https://github.com/opensearch-project/ml-commons-dashboards/pull/194))
-* Update plugin config to enable plugin by default. ([#200](https://github.com/opensearch-project/ml-commons-dashboards/pull/200))
 
 ### Infrastructure
 

--- a/release-notes/opensearch-ml-commons-dashboards.release-notes-2.8.0.0.md
+++ b/release-notes/opensearch-ml-commons-dashboards.release-notes-2.8.0.0.md
@@ -3,10 +3,6 @@
 Compatible with OpenSearch 2.8.0
 
 
-### Features
-
-* Remove experiment warning banner. ([#194](https://github.com/opensearch-project/ml-commons-dashboards/pull/194))
-
 ### Infrastructure
 
 * Update husky to 8.0.3 to remove execa as development dependency. ([#160](https://github.com/opensearch-project/ml-commons-dashboards/pull/160))

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,6 +19,6 @@ export { MlCommonsPluginSetup, MlCommonsPluginStart } from './types';
 
 export const config: PluginConfigDescriptor = {
   schema: schema.object({
-    enabled: schema.boolean({ defaultValue: true }),
+    enabled: schema.boolean({ defaultValue: false }),
   }),
 };


### PR DESCRIPTION
### Description
Since the ml-commons BE can't be GA, add back the experiment banner and disabled plugin by default.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
