### PR TITLE
Onboard jenkins build docker image to ml-commons-dashboards github ci checks

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -9,9 +9,22 @@ on:
 env:
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
 jobs:
+  Get-CI-Image-Tag:
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
+    with:
+      product: opensearch-dashboards
+
   tests:
     name: Run unit tests
     runs-on: ubuntu-latest
+    needs: Get-CI-Image-Tag
+    container:
+      # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
+      # this image tag is subject to change as more dependencies and updates will arrive over time
+      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
+      # need to switch to root so that github actions can install runner binary on container without permission issues.
+      options: --user root
+
     steps:
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2
@@ -19,31 +32,16 @@ jobs:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
           path: OpenSearch-Dashboards
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: './OpenSearch-Dashboards/.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
-      - name: Install Yarn
-        # Need to use bash to avoid having a windows/linux specific step
-        shell: bash
-        run: |
-          YARN_VERSION=$(node -p "require('./OpenSearch-Dashboards/package.json').engines.yarn")
-          echo "Installing yarn@$YARN_VERSION"
-          npm i -g yarn@$YARN_VERSION
-      - run: node -v
-      - run: yarn -v
       - name: Checkout ML Commons OpenSearch Dashboards plugin
         uses: actions/checkout@v2
         with:
           path: OpenSearch-Dashboards/plugins/ml-commons-dashboards
-      - name: Bootstrap plugin/opensearch-dashboards
+      - name: Bootstrap / build / unittest
         run: |
-          cd OpenSearch-Dashboards/plugins/ml-commons-dashboards
-          yarn osd bootstrap
-      - name: Run tests with coverage
-        run: |
-          cd OpenSearch-Dashboards/plugins/ml-commons-dashboards
-          yarn run test:jest --silent --coverage
+          chown -R 1000:1000 `pwd`
+          cd ./OpenSearch-Dashboards/
+          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
+                               cd ./plugins/ml-commons-dashboards &&
+                               whoami && yarn osd bootstrap && yarn run test:jest --silent --coverage"
       - name: Uploads coverage
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
### Description
Onboard jenkins build docker image to ml-commons-dashboards github ci checks

### Issues Resolved
https://github.com/opensearch-project/ml-commons-dashboards/issues/274

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
