### PR TITLE
Reset current page after data source change

### DIFF
--- a/public/components/monitoring/use_monitoring.ts
+++ b/public/components/monitoring/use_monitoring.ts
@@ -217,6 +217,7 @@ export const useMonitoring = () => {
       currentPage: previousValue.currentPage,
       pageSize: previousValue.pageSize,
       sort: previousValue.sort,
+      nameOrId: '',
       source: [],
       connector: [],
       status: undefined,
@@ -280,6 +281,9 @@ export const useMonitoring = () => {
   );
 
   useEffect(() => {
+    if (!dataSourceEnabled) {
+      return;
+    }
     setParams((previousParams) => {
       const dataSourceId = getDataSourceId(dataSourceEnabled, selectedDataSourceOption);
       if (previousParams.dataSourceId === dataSourceId) {
@@ -287,6 +291,7 @@ export const useMonitoring = () => {
       }
       return {
         ...previousParams,
+        currentPage: 1,
         dataSourceId,
         connector: [],
       };


### PR DESCRIPTION
### Description
This PR for fixing two bugs.
1. Reset current page after data source change.
2. Clear `params.nameOrId` after resetSearch called

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
