### PR TITLE
Reset to max page when current page overflow

### DIFF
--- a/public/components/monitoring/use_monitoring.ts
+++ b/public/components/monitoring/use_monitoring.ts
@@ -298,6 +298,21 @@ export const useMonitoring = () => {
     });
   }, [dataSourceEnabled, selectedDataSourceOption]);
 
+  useEffect(() => {
+    if (params.currentPage === 1 || !data) {
+      return;
+    }
+    const maxPage = Math.max(1, data.pagination.totalPages);
+    if (params.currentPage <= maxPage) {
+      return;
+    }
+
+    setParams((prevParams) => ({
+      ...prevParams,
+      currentPage: maxPage,
+    }));
+  }, [params, data]);
+
   return {
     params,
     pageStatus,


### PR DESCRIPTION
### Description
The PR is for fixing page always stay empty page when jump to no models page. This error always happens in below flow:
1. User visit deployed models list and total pages are 2.
2. User jump to 2 page, but the deployed models changed and total pages become 1.
3. Then the page will always stay empty page like below image
<img width="1142" alt="image" src="https://github.com/opensearch-project/ml-commons-dashboards/assets/4034161/00203c96-860d-4b4e-b58c-2b778482addd">
After this PR, the current page will reset to max page and resend the request. It will jump to page 1 in above cases.


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
