### PR TITLE
Register admin UI as ai models in data administration use case

### DIFF
--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AppMountParameters, CoreSetup, CoreStart, Plugin } from '../../../src/core/public';
+import { i18n } from '@osd/i18n';
+import {
+  AppMountParameters,
+  CoreSetup,
+  CoreStart,
+  DEFAULT_NAV_GROUPS,
+  Plugin,
+} from '../../../src/core/public';
 import {
   MlCommonsPluginPluginSetup,
   MlCommonsPluginPluginStart,
@@ -47,6 +54,18 @@ export class MlCommonsPluginPlugin
         return renderApp(params, services);
       },
     });
+
+    core.chrome.addNavLinksToGroup(DEFAULT_NAV_GROUPS.dataAdministration, [
+      {
+        id: PLUGIN_ID,
+        category: {
+          id: 'ai-model',
+          label: i18n.translate('MLCommonsDashboards.AIModels.Category', {
+            defaultMessage: 'ai models',
+          }),
+        },
+      },
+    ]);
 
     // Return methods that should be available to other plugins
     return {};


### PR DESCRIPTION
### Description
Register to data administration use case based [OSD feature/navigation-next branch](https://github.com/opensearch-project/OpenSearch-Dashboards/tree/feature/navigation-next).

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
