### PR TITLE
Use smaller and compressed varients of buttons and form components

### DIFF
--- a/public/components/common/copyable_text.tsx
+++ b/public/components/common/copyable_text.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useCallback, useState, useRef } from 'react';
-import { EuiButtonIcon, copyToClipboard, EuiToolTip } from '@elastic/eui';
+import { EuiSmallButtonIcon, copyToClipboard, EuiToolTip } from '@elastic/eui';
 
 interface Props {
   text: string;
@@ -33,7 +33,7 @@ export const CopyableText = ({
     <div data-test-subj="copyable-text-div">
       {iconLeft ? null : text}
       <EuiToolTip content={isTextCopied ? copiedTooltipText : tooltipText}>
-        <EuiButtonIcon
+        <EuiSmallButtonIcon
           buttonRef={copyButtonRef}
           aria-label="Copy ID to clipboard"
           color="text"

--- a/public/components/common/options_filter/options_filter.tsx
+++ b/public/components/common/options_filter/options_filter.tsx
@@ -8,7 +8,7 @@ import {
   EuiPopover,
   EuiPopoverTitle,
   EuiFieldSearch,
-  EuiFilterButton,
+  EuiSmallFilterButton,
   EuiPopoverFooter,
   EuiFlexGroup,
   EuiFlexItem,
@@ -73,14 +73,14 @@ export const OptionsFilter = <T extends string | number = string>({
   return (
     <EuiPopover
       button={
-        <EuiFilterButton
+        <EuiSmallFilterButton
           iconType="arrowDown"
           onClick={handleButtonClick}
           isSelected={isPopoverOpen}
           {...(value.length > 0 ? { hasActiveFilters: true, numActiveFilters: value.length } : {})}
         >
           {name}
-        </EuiFilterButton>
+        </EuiSmallFilterButton>
       }
       isOpen={isPopoverOpen}
       closePopover={closePopover}

--- a/public/components/common/refresh_interval.tsx
+++ b/public/components/common/refresh_interval.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiIcon,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFieldText,
   EuiPopover,
   EuiFlexGroup,
@@ -116,14 +116,14 @@ export const RefreshInterval = ({
   }, [interval, isPaused, onRefresh, onRefreshChange]);
 
   const intervalButton = (
-    <EuiButtonEmpty
+    <EuiSmallButtonEmpty
       iconType="arrowDown"
       iconSide="right"
       onClick={() => setIsPopoverOpen(!isPopoverOpen)}
       aria-label="set refresh interval"
     >
       <EuiIcon type="clock" />
-    </EuiButtonEmpty>
+    </EuiSmallButtonEmpty>
   );
 
   let errors: string[] = [];

--- a/public/components/common/refresh_interval.tsx
+++ b/public/components/common/refresh_interval.tsx
@@ -10,7 +10,7 @@ import {
   EuiPopover,
   EuiFlexGroup,
   EuiCompressedFieldNumber,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSmallButton,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -160,7 +160,7 @@ export const RefreshInterval = ({
                 />
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiSelect
+                <EuiCompressedSelect
                   aria-label="interval unit selector"
                   isInvalid={isInvalid}
                   value={intervalUnit}

--- a/public/components/common/refresh_interval.tsx
+++ b/public/components/common/refresh_interval.tsx
@@ -6,10 +6,10 @@
 import {
   EuiIcon,
   EuiSmallButtonEmpty,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiPopover,
   EuiFlexGroup,
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiSelect,
   EuiSmallButton,
   EuiFlexItem,
@@ -132,7 +132,7 @@ export const RefreshInterval = ({
   }
 
   return (
-    <EuiFieldText
+    <EuiCompressedFieldText
       aria-label="current interval value"
       readOnly
       value={displayedIntervalValue}
@@ -152,7 +152,7 @@ export const RefreshInterval = ({
           >
             <EuiFlexGroup>
               <EuiFlexItem>
-                <EuiFieldNumber
+                <EuiCompressedFieldNumber
                   aria-label="interval value input"
                   isInvalid={isInvalid}
                   value={intervalValue}

--- a/public/components/common/refresh_interval.tsx
+++ b/public/components/common/refresh_interval.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlexGroup,
   EuiFieldNumber,
   EuiSelect,
-  EuiButton,
+  EuiSmallButton,
   EuiFlexItem,
   EuiFormRow,
 } from '@elastic/eui';
@@ -169,14 +169,14 @@ export const RefreshInterval = ({
                 />
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiButton
+                <EuiSmallButton
                   aria-label={`${isPaused ? 'start' : 'stop'} refresh interval`}
                   disabled={isInvalid}
                   iconType={isPaused ? 'play' : 'stop'}
                   onClick={() => setIsPaused(!isPaused)}
                 >
                   {isPaused ? 'Start' : 'Stop'}
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFormRow>

--- a/public/components/common/refresh_interval.tsx
+++ b/public/components/common/refresh_interval.tsx
@@ -13,7 +13,7 @@ import {
   EuiSelect,
   EuiSmallButton,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
 } from '@elastic/eui';
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 
@@ -142,7 +142,7 @@ export const RefreshInterval = ({
           isOpen={isPopoverOpen}
           closePopover={() => setIsPopoverOpen(false)}
         >
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Refresh every"
             helpText={
               errors.length > 0 ? '' : 'Enter an auto-refresh rate greater than 10 seconds.'
@@ -179,7 +179,7 @@ export const RefreshInterval = ({
                 </EuiSmallButton>
               </EuiFlexItem>
             </EuiFlexGroup>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiPopover>
       }
     />

--- a/public/components/monitoring/model_deployment_table.tsx
+++ b/public/components/monitoring/model_deployment_table.tsx
@@ -11,7 +11,7 @@ import {
   Direction,
   EuiBasicTable,
   EuiSmallButton,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiEmptyPrompt,
   EuiHealth,
   EuiSpacer,
@@ -154,7 +154,7 @@ export const ModelDeploymentTable = ({
               anchorClassName="ml-modelModelIdCell"
             >
               {(copy) => (
-                <EuiButtonIcon
+                <EuiSmallButtonIcon
                   aria-label="Copy ID to clipboard"
                   color="text"
                   iconType="copy"
@@ -176,7 +176,7 @@ export const ModelDeploymentTable = ({
         render: (id: string, modelDeploymentItem: ModelDeploymentItem) => {
           return (
             <EuiToolTip content="View status details">
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 onClick={() => {
                   onViewDetail?.(modelDeploymentItem);
                 }}

--- a/public/components/monitoring/model_deployment_table.tsx
+++ b/public/components/monitoring/model_deployment_table.tsx
@@ -10,7 +10,7 @@ import {
   Criteria,
   Direction,
   EuiBasicTable,
-  EuiSmallButton,
+  EuiButton,
   EuiSmallButtonIcon,
   EuiEmptyPrompt,
   EuiHealth,
@@ -276,9 +276,9 @@ export const ModelDeploymentTable = ({
                   actions={
                     <>
                       <EuiSpacer size="s" />
-                      <EuiSmallButton role="button" onClick={onResetSearchClick} size="m">
+                      <EuiButton role="button" onClick={onResetSearchClick} size="m">
                         Reset search
-                      </EuiSmallButton>
+                      </EuiButton>
                     </>
                   }
                   aria-label="no models results"

--- a/public/components/monitoring/model_deployment_table.tsx
+++ b/public/components/monitoring/model_deployment_table.tsx
@@ -10,7 +10,7 @@ import {
   Criteria,
   Direction,
   EuiBasicTable,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonIcon,
   EuiEmptyPrompt,
   EuiHealth,
@@ -276,9 +276,9 @@ export const ModelDeploymentTable = ({
                   actions={
                     <>
                       <EuiSpacer size="s" />
-                      <EuiButton role="button" onClick={onResetSearchClick} size="m">
+                      <EuiSmallButton role="button" onClick={onResetSearchClick} size="m">
                         Reset search
-                      </EuiButton>
+                      </EuiSmallButton>
                     </>
                   }
                   aria-label="no models results"

--- a/public/components/monitoring/search_bar.tsx
+++ b/public/components/monitoring/search_bar.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { useMemo, useCallback } from 'react';
-import { EuiFieldSearch } from '@elastic/eui';
+import { EuiCompressedFieldSearch } from '@elastic/eui';
 import { debounce } from 'lodash';
 interface SearchBarProps {
   onSearch: (value: string) => void;
@@ -20,7 +20,7 @@ export const SearchBar = ({ onSearch, inputRef }: SearchBarProps) => {
   );
 
   return (
-    <EuiFieldSearch
+    <EuiCompressedFieldSearch
       autoFocus
       inputRef={inputRef}
       placeholder="Search by model name or ID"

--- a/public/components/status_filter/index.tsx
+++ b/public/components/status_filter/index.tsx
@@ -8,7 +8,7 @@ import {
   EuiPopover,
   EuiPopoverTitle,
   EuiFilterGroup,
-  EuiFilterButton,
+  EuiSmallFilterButton,
   EuiSelectable,
   EuiSelectableOption,
   EuiIcon,
@@ -66,7 +66,7 @@ export const StatusFilter = ({ onUpdateFilters, options, loading }: Props) => {
   );
 
   const button = (
-    <EuiFilterButton
+    <EuiSmallFilterButton
       iconType="arrowDown"
       onClick={onButtonClick}
       isSelected={isPopoverOpen}
@@ -76,7 +76,7 @@ export const StatusFilter = ({ onUpdateFilters, options, loading }: Props) => {
       isLoading={loading}
     >
       Status
-    </EuiFilterButton>
+    </EuiSmallFilterButton>
   );
 
   return (


### PR DESCRIPTION
### Description
Replace instances of `EuiButton` that don't have an explicit sizing attribute to `EuiSmallButton*`.
Replace instances of `Eui<form elements>` that don't have density attributes to `EuiCompressed<form elements>`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
