### PR TITLE
Support new page header

### DIFF
--- a/public/application.tsx
+++ b/public/application.tsx
@@ -35,6 +35,7 @@ export const renderApp = (
             setActionMenu={setHeaderActionMenu}
             dataSource={services.dataSource}
             dataSourceManagement={services.dataSourceManagement}
+            application={services.application}
           />
         </services.i18n.Context>
       </OpenSearchDashboardsContextProvider>

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { I18nProvider } from '@osd/i18n/react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { EuiPage, EuiPageBody } from '@elastic/eui';
+import { useObservable } from 'react-use';
 import { ROUTES } from '../../common/router';
 import { routerPaths } from '../../common/router_paths';
 
@@ -37,6 +38,7 @@ interface MlCommonsPluginAppDeps {
   dataSource?: DataSourcePluginSetup;
   dataSourceManagement?: DataSourceManagementPluginSetup;
   setActionMenu: (menuMount: MountPoint | undefined) => void;
+  application: CoreStart['application'];
 }
 
 export interface ComponentsCommonProps {
@@ -55,8 +57,12 @@ export const MlCommonsPluginApp = ({
   dataSourceManagement,
   savedObjects,
   setActionMenu,
+  navigation,
+  uiSettingsClient,
+  application,
 }: MlCommonsPluginAppDeps) => {
   const dataSourceEnabled = !!dataSource;
+  const useNewPageHeader = useObservable(uiSettingsClient.get$('home:useNewHomePage'));
   return (
     <I18nProvider>
       <DataSourceContextProvider
@@ -73,7 +79,15 @@ export const MlCommonsPluginApp = ({
                     key={path}
                     path={path}
                     render={() => (
-                      <Component http={http} notifications={notifications} data={data} />
+                      <Component
+                        http={http}
+                        notifications={notifications}
+                        chrome={chrome}
+                        data={data}
+                        navigation={navigation}
+                        useNewPageHeader={useNewPageHeader}
+                        application={application}
+                      />
                     )}
                     exact={exact ?? false}
                   />
@@ -82,7 +96,8 @@ export const MlCommonsPluginApp = ({
               </Switch>
             </EuiPageBody>
           </EuiPage>
-          <GlobalBreadcrumbs chrome={chrome} basename={basename} />
+          {/* Breadcrumbs will contains dynamic content in new page header, should be provided by each page self*/}
+          {!useNewPageHeader && <GlobalBreadcrumbs chrome={chrome} basename={basename} />}
           {dataSourceEnabled && (
             <DataSourceTopNavMenu
               notifications={notifications}

--- a/public/components/monitoring/__tests__/monitoring_page_header.test.tsx
+++ b/public/components/monitoring/__tests__/monitoring_page_header.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { applicationServiceMock } from '../../../../../../src/core/public/mocks';
+import { navigationPluginMock } from '../../../../../../src/plugins/navigation/public/mocks';
+
+import { render, screen } from '../../../../test/test_utils';
+import { MonitoringPageHeader, MonitoringPageHeaderProps } from '../monitoring_page_header';
+
+jest.mock('../../../apis/connector');
+
+async function setup(options: Partial<MonitoringPageHeaderProps>) {
+  const setBreadcrumbsMock = jest.fn();
+  const onRefreshMock = jest.fn();
+  const applicationStartMock = applicationServiceMock.createStartContract();
+  const navigationStartMock = navigationPluginMock.createStartContract();
+  const user = userEvent.setup({});
+
+  navigationStartMock.ui.HeaderControl = ({ controls }) => {
+    return controls?.[0].renderComponent ?? null;
+  };
+
+  const renderResult = render(
+    <MonitoringPageHeader
+      navigation={navigationStartMock}
+      application={applicationStartMock}
+      setBreadcrumbs={setBreadcrumbsMock}
+      onRefresh={onRefreshMock}
+      useNewPageHeader={true}
+      {...options}
+    />
+  );
+
+  return {
+    user,
+    renderResult,
+    setBreadcrumbsMock,
+    onRefreshMock,
+    applicationStartMock,
+    navigationStartMock,
+  };
+}
+
+describe('<MonitoringPageHeader />', () => {
+  it('should old page header and refresh button when usePageHeader is false', async () => {
+    await setup({
+      useNewPageHeader: false,
+    });
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+    expect(screen.getByLabelText('set refresh interval')).toBeInTheDocument();
+  });
+
+  it('should set breadcrumbs and render refresh button', async () => {
+    const { setBreadcrumbsMock } = await setup({
+      useNewPageHeader: true,
+      recordsCount: 2,
+    });
+
+    expect(setBreadcrumbsMock).toHaveBeenCalledWith([
+      {
+        text: 'AI Models(2)',
+      },
+    ]);
+    expect(screen.getByLabelText('set refresh interval')).toBeInTheDocument();
+  });
+});

--- a/public/components/monitoring/index.tsx
+++ b/public/components/monitoring/index.tsx
@@ -5,7 +5,6 @@
 
 import {
   EuiPanel,
-  EuiPageHeader,
   EuiSpacer,
   EuiTextColor,
   EuiFlexGroup,
@@ -14,10 +13,12 @@ import {
   EuiFilterGroup,
 } from '@elastic/eui';
 import React, { useState, useRef, useCallback } from 'react';
+import { FormattedMessage } from '@osd/i18n/react';
 
 import { ModelDeploymentProfile } from '../../apis/profile';
-import { RefreshInterval } from '../common/refresh_interval';
 import { PreviewPanel } from '../preview_panel';
+import { ApplicationStart, ChromeStart } from '../../../../../src/core/public';
+import { NavigationPublicPluginStart } from '../../../../../src/plugins/navigation/public';
 
 import { ModelDeploymentItem, ModelDeploymentTable } from './model_deployment_table';
 import { useMonitoring } from './use_monitoring';
@@ -25,8 +26,17 @@ import { ModelStatusFilter } from './model_status_filter';
 import { SearchBar } from './search_bar';
 import { ModelSourceFilter } from './model_source_filter';
 import { ModelConnectorFilter } from './model_connector_filter';
+import { MonitoringPageHeader } from './monitoring_page_header';
 
-export const Monitoring = () => {
+interface MonitoringProps {
+  chrome: ChromeStart;
+  navigation: NavigationPublicPluginStart;
+  application: ApplicationStart;
+  useNewPageHeader: boolean;
+}
+
+export const Monitoring = (props: MonitoringProps) => {
+  const { useNewPageHeader, chrome, application, navigation } = props;
   const {
     pageStatus,
     params,
@@ -83,25 +93,34 @@ export const Monitoring = () => {
   );
 
   return (
-    <div>
-      <EuiSpacer size="s" />
-      <EuiSpacer size="xs" />
-      <EuiPageHeader
-        pageTitle="Overview"
-        rightSideItems={[<RefreshInterval onRefresh={reload} />]}
+    <>
+      <MonitoringPageHeader
+        onRefresh={reload}
+        navigation={navigation}
+        setBreadcrumbs={chrome.setBreadcrumbs}
+        recordsCount={pagination?.totalRecords}
+        application={application}
+        useNewPageHeader={useNewPageHeader}
       />
-      <EuiSpacer size="m" />
       <EuiPanel>
-        <EuiText size="s">
-          <h2>
-            Models{' '}
-            {pageStatus !== 'empty' && (
-              <EuiTextColor aria-label="total number of results" color="subdued">
-                ({pagination?.totalRecords ?? 0})
-              </EuiTextColor>
-            )}
-          </h2>
-        </EuiText>
+        {!useNewPageHeader && (
+          <EuiText size="s">
+            <h2>
+              <FormattedMessage
+                id="machineLearning.aiModels.table.header.title"
+                defaultMessage="Models {records}"
+                values={{
+                  records:
+                    pageStatus === 'normal' ? (
+                      <EuiTextColor aria-label="total number of results" color="subdued">
+                        ({pagination?.totalRecords ?? 0})
+                      </EuiTextColor>
+                    ) : undefined,
+                }}
+              />
+            </h2>
+          </EuiText>
+        )}
 
         <EuiSpacer size="m" />
         {pageStatus !== 'empty' && (
@@ -145,6 +164,6 @@ export const Monitoring = () => {
           />
         )}
       </EuiPanel>
-    </div>
+    </>
   );
 };

--- a/public/components/monitoring/monitoring_page_header.tsx
+++ b/public/components/monitoring/monitoring_page_header.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import React, { useEffect, useMemo } from 'react';
+import { EuiPageHeader, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+
+import type { ChromeBreadcrumb } from 'opensearch-dashboards/public';
+
+import { RefreshInterval } from '../common/refresh_interval';
+import { NavigationPublicPluginStart } from '../../../../../src/plugins/navigation/public';
+import { ApplicationStart } from '../../../../../src/core/public';
+
+export interface MonitoringPageHeaderProps {
+  navigation: NavigationPublicPluginStart;
+  application: ApplicationStart;
+  onRefresh: () => void;
+  recordsCount?: number;
+  setBreadcrumbs: (breadcrumbs: ChromeBreadcrumb[]) => void;
+  useNewPageHeader: boolean;
+}
+
+export const MonitoringPageHeader = ({
+  onRefresh,
+  navigation,
+  recordsCount,
+  setBreadcrumbs,
+  application,
+  useNewPageHeader,
+}: MonitoringPageHeaderProps) => {
+  const { HeaderControl } = navigation.ui;
+  const { setAppRightControls } = application;
+  const controls = useMemo(() => {
+    if (useNewPageHeader) {
+      return [
+        {
+          renderComponent: <RefreshInterval onRefresh={onRefresh} />,
+        },
+      ];
+    }
+    return [];
+  }, [useNewPageHeader, onRefresh]);
+
+  useEffect(() => {
+    if (useNewPageHeader) {
+      setBreadcrumbs([
+        {
+          text: i18n.translate('machineLearning.AIModels.page.title', {
+            defaultMessage:
+              'AI Models{recordsCount, select, undefined {} other {({recordsCount})}}',
+            values: {
+              recordsCount,
+            },
+          }),
+        },
+      ]);
+    }
+  }, [useNewPageHeader, recordsCount, setBreadcrumbs]);
+
+  if (useNewPageHeader) {
+    return <HeaderControl setMountPoint={setAppRightControls} controls={controls} />;
+  }
+  return (
+    <>
+      <EuiSpacer size="s" />
+      <EuiSpacer size="xs" />
+      <EuiPageHeader
+        pageTitle="Overview"
+        rightSideItems={[<RefreshInterval onRefresh={onRefresh} />]}
+      />
+      <EuiSpacer size="m" />
+    </>
+  );
+};


### PR DESCRIPTION
### Description
This PR is for supporting new page header. It mainly includes below changes:
1. Hide table header title and global breadcrumbs when useNewPageHeader enabled
2. Set new breadcrumbs and register refresh component when useNewPageHeader enabled

This PR is pending https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7630.

#### DO NOT MERGED IF PENDING PR NOT MERGED!

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
