### PR TITLE
Fix category order and description in data administration landing page

### DIFF
--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -30,6 +30,9 @@ export class MlCommonsPluginPlugin
     core.application.register({
       id: PLUGIN_ID,
       title: PLUGIN_NAME,
+      description: i18n.translate('MLCommonsDashboards.application.aiModels.description', {
+        defaultMessage: 'Review  the status of running AI models.',
+      }),
       category: {
         id: 'opensearch',
         label: 'OpenSearch Plugins',
@@ -66,6 +69,7 @@ export class MlCommonsPluginPlugin
           label: i18n.translate('MLCommonsDashboards.Category.MachineLearning.label', {
             defaultMessage: 'Machine learning',
           }),
+          order: 9999,
         },
       },
     ]);

--- a/release-notes/opensearch-ml-commons-dashboards.release-notes-2.17.0.0.md
+++ b/release-notes/opensearch-ml-commons-dashboards.release-notes-2.17.0.0.md
@@ -11,6 +11,7 @@ Compatible with OpenSearch 2.17.0
 
 ### Bug Fixes
 * Fix connector router response 500 ([#358](https://github.com/opensearch-project/ml-commons-dashboards/pull/358))
+* Fix category order and description in data administration landing page ([#369](https://github.com/opensearch-project/ml-commons-dashboards/pull/369))
 
 ### Maintenance
 * Increment version to 2.17.0.0 ([#353](https://github.com/opensearch-project/ml-commons-dashboards/pull/353))


### PR DESCRIPTION
### Description
This PR is for fixing the category order and description in the data administration landing page. These two kind of things will be updated like below image:
![image](https://github.com/user-attachments/assets/2210d91f-a11c-4043-9311-e6153bb8b267)



### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
