### PR TITLE
Reduce machine learning table spacing when new home page enabled

### DIFF
--- a/public/components/common/refresh_interval.tsx
+++ b/public/components/common/refresh_interval.tsx
@@ -98,9 +98,14 @@ export const RefreshInterval = ({
       }
     } else {
       if (interval !== null) {
+        /**
+         * According https://developer.mozilla.org/en-US/docs/Web/API/setInterval#return_value
+         * the max delayed value of setInterval is 2147483647, the inner function will be executed immediately
+         * if the delayed value is greater than 2147483647. Add a Math.min here to avoid been executed immediately.
+         **/
         intervalId = window.setInterval(() => {
           onRefresh();
-        }, interval);
+        }, Math.min(interval, 2147483647));
       }
     }
 

--- a/public/components/common/refresh_interval.tsx
+++ b/public/components/common/refresh_interval.tsx
@@ -38,6 +38,8 @@ const intervalUnitOptions = [
   { text: 'hours', value: 'h' },
 ];
 
+const MAX_SIGNED_32_BIT_INTEGER = 2147483647;
+
 export const RefreshInterval = ({
   onRefresh,
   onRefreshChange,
@@ -100,12 +102,12 @@ export const RefreshInterval = ({
       if (interval !== null) {
         /**
          * According https://developer.mozilla.org/en-US/docs/Web/API/setInterval#return_value
-         * the max delayed value of setInterval is 2147483647, the inner function will be executed immediately
-         * if the delayed value is greater than 2147483647. Add a Math.min here to avoid been executed immediately.
+         * the max delayed value of setInterval is MAX_SIGNED_32_BIT_INTEGER, the inner function will be executed immediately
+         * if the delayed value is greater than MAX_SIGNED_32_BIT_INTEGER. Add a Math.min here to avoid been executed immediately.
          **/
         intervalId = window.setInterval(() => {
           onRefresh();
-        }, Math.min(interval, 2147483647));
+        }, Math.min(interval, MAX_SIGNED_32_BIT_INTEGER));
       }
     }
 

--- a/public/components/monitoring/index.tsx
+++ b/public/components/monitoring/index.tsx
@@ -104,28 +104,29 @@ export const Monitoring = (props: MonitoringProps) => {
       />
       <EuiPanel>
         {!useNewPageHeader && (
-          <EuiText size="s">
-            <h2>
-              <FormattedMessage
-                id="machineLearning.aiModels.table.header.title"
-                defaultMessage="Models {records}"
-                values={{
-                  records:
-                    pageStatus === 'normal' ? (
-                      <EuiTextColor aria-label="total number of results" color="subdued">
-                        ({pagination?.totalRecords ?? 0})
-                      </EuiTextColor>
-                    ) : undefined,
-                }}
-              />
-            </h2>
-          </EuiText>
+          <>
+            <EuiText size="s">
+              <h2>
+                <FormattedMessage
+                  id="machineLearning.aiModels.table.header.title"
+                  defaultMessage="Models {records}"
+                  values={{
+                    records:
+                      pageStatus === 'normal' ? (
+                        <EuiTextColor aria-label="total number of results" color="subdued">
+                          ({pagination?.totalRecords ?? 0})
+                        </EuiTextColor>
+                      ) : undefined,
+                  }}
+                />
+              </h2>
+            </EuiText>
+            <EuiSpacer size="m" />
+          </>
         )}
-
-        <EuiSpacer size="m" />
         {pageStatus !== 'empty' && (
           <>
-            <EuiFlexGroup gutterSize="l">
+            <EuiFlexGroup gutterSize={useNewPageHeader ? 's' : 'l'}>
               <EuiFlexItem>
                 <SearchBar inputRef={setInputRef} onSearch={searchByNameOrId} />
               </EuiFlexItem>

--- a/public/components/monitoring/monitoring_page_header.tsx
+++ b/public/components/monitoring/monitoring_page_header.tsx
@@ -35,7 +35,11 @@ export const MonitoringPageHeader = ({
     if (useNewPageHeader) {
       return [
         {
-          renderComponent: <RefreshInterval onRefresh={onRefresh} />,
+          renderComponent: (
+            <div style={{ width: 227 }}>
+              <RefreshInterval onRefresh={onRefresh} />
+            </div>
+          ),
         },
       ];
     }


### PR DESCRIPTION
### Description
This PR is for reducing spacing in AI models table when new home page enabled, mainly include below updates:
1. Reduce spacing between search bar and filters to 8px
2. Remove spacing between search bar and panel top
3. Add fixed width to `RefreshInterval` avoid input overflow 
![image](https://github.com/user-attachments/assets/48263a0a-506f-4f96-ae3f-edc5ea619a8e)
This PR also include one bug fixing for refresh with a very large number. The refresh API will be called many times after input a very large delay number.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
