### PR TITLE
Bump opensearch to 3.0.0.0-alpha1

### DIFF
--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -2,7 +2,7 @@ name: 'Install Dashboards with Plugin via Binary'
 
 on: [push, pull_request]
 env:
-  OPENSEARCH_VERSION: '3.0.0'
+  OPENSEARCH_VERSION: '3.0.0-alpha1'
   CI: 1
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest]
         # TODO: add windows support when OSD core is stable on windows
     runs-on: ${{ matrix.os }}
-    steps:  
+    steps:
       - name: Checkout Branch
         uses: actions/checkout@v3
 
@@ -44,12 +44,12 @@ jobs:
           install_zip: true
 
       - name: Start the binary
-        run: | 
+        run: |
           nohup ./bin/opensearch-dashboards &
         working-directory: ${{ steps.setup-dashboards.outputs.dashboards-binary-directory }}
         shell: bash
 
-      - name: Health check 
+      - name: Health check
         run: |
           timeout 300 bash -c 'while [[ "$(curl http://localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
         shell: bash

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,6 +1,6 @@
 {
   "id": "mlCommonsDashboards",
-  "version": "3.0.0.0",
+  "version": "3.0.0.0-alpha1",
   "opensearchDashboardsVersion": "3.0.0",
   "server": true,
   "ui": true,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "config": {
     "id": "mlCommonsDashboards"
   },
-  "version": "3.0.0.0",
+  "version": "3.0.0.0-alpha1",
   "scripts": {
     "build": "yarn plugin-helpers build",
     "plugin-helpers": "node ../../scripts/plugin_helpers",


### PR DESCRIPTION
### Description
Bump opensearch to 3.0.0.0-alpha1, according https://github.com/opensearch-project/dashboards-query-workbench/pull/444

### Issues Resolved
A part of #234 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
