### PR TITLE
Fix data source not compatible with prerelease

### DIFF
--- a/public/utils/__tests__/data_source.test.ts
+++ b/public/utils/__tests__/data_source.test.ts
@@ -59,6 +59,22 @@ describe('isDataSourceCompatible', () => {
         },
       })
     ).toBe(true);
+    expect(
+      isDataSourceCompatible({
+        attributes: {
+          installedPlugins: ['opensearch-ml'],
+          dataSourceVersion: '3.0.0-alpha1',
+        },
+      })
+    ).toBe(true);
+    expect(
+      isDataSourceCompatible({
+        attributes: {
+          installedPlugins: ['opensearch-ml'],
+          dataSourceVersion: '3.0.0-beta1',
+        },
+      })
+    ).toBe(true);
   });
 
   it('should return false for un-compatible data sources', () => {

--- a/public/utils/data_source.ts
+++ b/public/utils/data_source.ts
@@ -49,7 +49,10 @@ export const isDataSourceCompatible = (dataSource: SavedObject<DataSourceAttribu
     'supportedOSDataSourceVersions' in pluginManifest &&
     !semver.satisfies(
       dataSource.attributes.dataSourceVersion,
-      pluginManifest.supportedOSDataSourceVersions
+      pluginManifest.supportedOSDataSourceVersions,
+      {
+        includePrerelease: true,
+      }
     )
   ) {
     return false;


### PR DESCRIPTION
### Description
This PR is for fixing the data source compatible setting in the data source selector. The data source selector can working fine with pre-release such as `3.0.0-alpha1` or `3.0.0-beta1`.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
