### PR TITLE
Fix data source picker to filter out unsupported engine types

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -14,5 +14,6 @@
   ],
   "optionalPlugins": ["dataSource", "dataSourceManagement"],
   "supportedOSDataSourceVersions": ">=2.9.0",
-  "requiredOSDataSourcePlugins": ["opensearch-ml"]
+  "requiredOSDataSourcePlugins": ["opensearch-ml"],
+  "unsupportedOSDataSourceEngineTypes": ["AnalyticEngine"]
 }

--- a/public/utils/__tests__/data_source.test.ts
+++ b/public/utils/__tests__/data_source.test.ts
@@ -77,6 +77,30 @@ describe('isDataSourceCompatible', () => {
     ).toBe(true);
   });
 
+  it('should return false for data sources with unsupported engine type', () => {
+    expect(
+      isDataSourceCompatible({
+        attributes: {
+          installedPlugins: ['opensearch-ml'],
+          dataSourceVersion: '2.13.0',
+          dataSourceEngineType: 'AnalyticEngine',
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('should return true for data sources with supported engine type', () => {
+    expect(
+      isDataSourceCompatible({
+        attributes: {
+          installedPlugins: ['opensearch-ml'],
+          dataSourceVersion: '2.13.0',
+          dataSourceEngineType: 'OpenSearch',
+        },
+      })
+    ).toBe(true);
+  });
+
   it('should return false for un-compatible data sources', () => {
     expect(
       isDataSourceCompatible({

--- a/public/utils/data_source.ts
+++ b/public/utils/data_source.ts
@@ -57,5 +57,17 @@ export const isDataSourceCompatible = (dataSource: SavedObject<DataSourceAttribu
   ) {
     return false;
   }
+
+  // filter out data sources with unsupported engine types
+  if (
+    'unsupportedOSDataSourceEngineTypes' in pluginManifest &&
+    dataSource.attributes.dataSourceEngineType &&
+    pluginManifest.unsupportedOSDataSourceEngineTypes.includes(
+      dataSource.attributes.dataSourceEngineType
+    )
+  ) {
+    return false;
+  }
+
   return true;
 };


### PR DESCRIPTION
## Description

Fix the data source picker to filter out data sources with unsupported engine types. Without this fix, data sources with `AnalyticEngine` engine type (OpenSearch domains with `cluster.pluggable.dataformat=composite`) appear in the picker even though the ml-commons plugin does not support them.

## Changes

- Added `unsupportedOSDataSourceEngineTypes: ["AnalyticEngine"]` to `opensearch_dashboards.json` manifest
- Updated `isDataSourceCompatible()` in `public/utils/data_source.ts` to check `dataSourceEngineType` against the manifest's unsupported list
- Added unit tests for the engine type filter logic

## Related

- opensearch-project/OpenSearch-Dashboards#12023
- opensearch-project/OpenSearch-Dashboards#12073