### PR TITLE
Fix test failure due to hapi import

### DIFF
--- a/server/routes/router.mock.ts
+++ b/server/routes/router.mock.ts
@@ -12,8 +12,6 @@ import {
   ServerRealm,
   ServerStateCookieOptions,
 } from '@hapi/hapi';
-// @ts-ignore
-import Response from '@hapi/hapi/lib/response';
 import { ProxyHandlerOptions } from '@hapi/h2o2';
 import { ReplyFileHandlerOptions } from '@hapi/inert';
 import { httpServerMock } from '../../../../src/core/server/http/http_server.mocks';
@@ -89,8 +87,12 @@ export class MockResponseToolkit implements ResponseToolkit {
   proxy(options: ProxyHandlerOptions): Promise<ResponseObject> {
     throw new Error('Method not implemented.');
   }
-  response(payload: unknown) {
-    return new Response(payload);
+  response(payload: unknown): ResponseObject {
+    const obj = { source: payload } as ResponseObject;
+    obj.code = () => obj;
+    obj.header = () => obj;
+    obj.type = () => obj;
+    return obj;
   }
 }
 


### PR DESCRIPTION
### Description
Fix test failure due to unresolved import: https://github.com/opensearch-project/ml-commons-dashboards/actions/runs/27316710486/job/80715117340?pr=491

```
FAIL server/routes/__tests__/model_router.test.ts
  ● Test suite failed to run

    Cannot find module '@hapi/hoek/assert' from '../../node_modules/@hapi/validate/lib/index.js'

    Require stack:
      /__w/ml-commons-dashboards/ml-commons-dashboards/OpenSearch-Dashboards/node_modules/@hapi/validate/lib/index.js
      /__w/ml-commons-dashboards/ml-commons-dashboards/OpenSearch-Dashboards/node_modules/@hapi/podium/lib/index.js
      /__w/ml-commons-dashboards/ml-commons-dashboards/OpenSearch-Dashboards/node_modules/@hapi/hapi/lib/response.js
      server/routes/router.mock.ts
      server/routes/__tests__/model_router.test.ts

      14 | } from '@hapi/hapi';
      15 | // @ts-ignore
    > 16 | import Response from '@hapi/hapi/lib/response';
         | ^
      17 | import { ProxyHandlerOptions } from '@hapi/h2o2';
      18 | import { ReplyFileHandlerOptions } from '@hapi/inert';
      19 | import { httpServerMock } from '../../../../src/core/server/http/http_server.mocks';

      at Resolver.resolveModule (../../node_modules/jest-resolve/build/resolver.js:324:11)
      at Object.<anonymous> (../../node_modules/@hapi/validate/lib/index.js:3:16)
      at Object.<anonymous> (../../node_modules/@hapi/podium/lib/index.js:5:18)
      at Object.<anonymous> (../../node_modules/@hapi/hapi/lib/response.js:8:16)
      at Object.<anonymous> (server/routes/router.mock.ts:16:1)
      at Object.<anonymous> (server/routes/__tests__/model_router.test.ts:10:1)
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
