### PR TITLE
Update MAINTAINERS.md to reflect emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,8 +8,13 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer  | GitHub ID                                 | Affiliation |
-| ----------- | ----------------------------------------- | ----------- |
-| Yulong Ruan | [ruanyl](https://github.com/ruanyl)       | Amazon      |
-| Lin Wang    | [wanglam](https://github.com/wanglam)     | Amazon      |
-| Tianyu Gao  | [raintygao](https://github.com/raintygao) | Amazon      |
+| Maintainer  | GitHub ID                             | Affiliation |
+| ----------- | ------------------------------------- | ----------- |
+| Yulong Ruan | [ruanyl](https://github.com/ruanyl)   | Amazon      |
+| Lin Wang    | [wanglam](https://github.com/wanglam) | Amazon      |
+
+## Emeritus
+
+| Maintainer | GitHub ID                                 | Affiliation |
+| ---------- | ----------------------------------------- | ----------- |
+| Tianyu Gao | [raintygao](https://github.com/raintygao) | Amazon      |


### PR DESCRIPTION
### Description
Moved Tianyu Gao to Emeritus section.
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
