### PR TITLE
Fix CVE-2026-33671, CVE-2026-33672, CVE-2026-33532

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
     "@testing-library/user-event": "^14.4.3",
     "husky": "^8.0.0",
     "lint-staged": "^10.0.0"
+  },
+  "resolutions": {
+    "picomatch": "^2.3.2",
+    "yaml": "^1.10.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,7 +442,7 @@ picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.3.1:
+picomatch@^2.3.1, picomatch@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
@@ -621,7 +621,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-yaml@^1.10.0:
+yaml@^1.10.0, yaml@^1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
   integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==


### PR DESCRIPTION
### Description

Add yarn resolutions to enforce minimum patched versions for transitive dependencies:

- **picomatch >=2.3.2** — fixes CVE-2026-33671 (ReDoS via extglob quantifiers) and CVE-2026-33672 (method injection in POSIX bracket expressions)
- **yaml >=1.10.3** — fixes CVE-2026-33532 (stack overflow DoS via deeply nested YAML collections)

Both are patch-level updates within the same major version, with no API changes.

### Testing

All 169 unit tests pass across 28 test suites.

### Issues Resolved

- https://nvd.nist.gov/vuln/detail/CVE-2026-33671
- https://nvd.nist.gov/vuln/detail/CVE-2026-33672
- https://nvd.nist.gov/vuln/detail/CVE-2026-33532

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff.