### PR TITLE
Fix CVE-2026-33671, CVE-2026-33672, CVE-2026-33532 in 2.19

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -482,9 +482,9 @@ path-type@^4.0.0:
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
 picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"
@@ -668,6 +668,6 @@ wrappy@1:
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 yaml@^1.10.0:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
+  integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==


### PR DESCRIPTION
### Description

Update yarn.lock to patched versions for transitive dependencies:

- picomatch 2.3.1 → 2.3.2 (fixes CVE-2026-33671 ReDoS via extglob, CVE-2026-33672 method injection in POSIX classes)
- yaml 1.10.2 → 1.10.3 (fixes CVE-2026-33532 stack overflow DoS via deeply nested collections)

Both are patch-level updates already merged on main.

### Dependencies

This PR depends on #498.

### Issues Resolved

- https://nvd.nist.gov/vuln/detail/CVE-2026-33671
- https://nvd.nist.gov/vuln/detail/CVE-2026-33672
- https://nvd.nist.gov/vuln/detail/CVE-2026-33532

### Check List
- [x] Commits are signed per the DCO using --signoff.