### PR TITLE
Adopt ESLint 10 / flat config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,0 @@
-node_modules
-/data
-/optimize
-/build
-/target
-/.eslintrc.js

--- a/.github/workflows/lint-workflow.yml
+++ b/.github/workflows/lint-workflow.yml
@@ -44,4 +44,4 @@ jobs:
       - name: Run lint
         run: |
           cd OpenSearch-Dashboards/plugins/ml-commons-dashboards
-          yarn run lint:es --ext .tsx --ext .ts .
+          yarn run lint:es

--- a/common/model.ts
+++ b/common/model.ts
@@ -49,9 +49,4 @@ export interface OpenSearchCustomerModel extends OpenSearchModelBase {
 }
 
 export type ModelSearchSort =
-  | 'name-asc'
-  | 'name-desc'
-  | 'id-asc'
-  | 'model_state-asc'
-  | 'model_state-desc'
-  | 'id-desc';
+  'name-asc' | 'name-desc' | 'id-asc' | 'model_state-asc' | 'model_state-desc' | 'id-desc';

--- a/common/status.ts
+++ b/common/status.ts
@@ -13,4 +13,4 @@ export const STATUS_FILTER = [
   { label: 'Not responding', color: '#BD271E', value: 'not-responding' },
 ] as const;
 
-export type STATUS_VALUE = typeof STATUS_FILTER[number]['value'];
+export type STATUS_VALUE = (typeof STATUS_FILTER)[number]['value'];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const osdConfig = require('@elastic/eslint-config-kibana');
+const { eui } = require('@elastic/eslint-config-kibana/extras');
+
+module.exports = [
+  // Replaces .eslintignore (ESLint 10 no longer reads it).
+  { ignores: ['node_modules', 'data', 'optimize', 'build', 'target'] },
+  ...osdConfig,
+  ...eui,
+];

--- a/public/components/common/options_filter/options_filter_item.tsx
+++ b/public/components/common/options_filter/options_filter_item.tsx
@@ -6,8 +6,10 @@
 import React, { useCallback } from 'react';
 import { EuiFilterSelectItem, EuiFilterSelectItemProps } from '@elastic/eui';
 
-export interface OptionsFilterItemProps<T extends string | number>
-  extends Pick<EuiFilterSelectItemProps, 'checked' | 'children'> {
+export interface OptionsFilterItemProps<T extends string | number> extends Pick<
+  EuiFilterSelectItemProps,
+  'checked' | 'children'
+> {
   value: T;
   onClick: (value: T) => void;
 }

--- a/public/components/common/refresh_interval.tsx
+++ b/public/components/common/refresh_interval.tsx
@@ -105,9 +105,12 @@ export const RefreshInterval = ({
          * the max delayed value of setInterval is MAX_SIGNED_32_BIT_INTEGER, the inner function will be executed immediately
          * if the delayed value is greater than MAX_SIGNED_32_BIT_INTEGER. Add a Math.min here to avoid been executed immediately.
          **/
-        intervalId = window.setInterval(() => {
-          onRefresh();
-        }, Math.min(interval, MAX_SIGNED_32_BIT_INTEGER));
+        intervalId = window.setInterval(
+          () => {
+            onRefresh();
+          },
+          Math.min(interval, MAX_SIGNED_32_BIT_INTEGER)
+        );
       }
     }
 
@@ -129,7 +132,7 @@ export const RefreshInterval = ({
       onClick={() => setIsPopoverOpen(!isPopoverOpen)}
       aria-label="set refresh interval"
     >
-      <EuiIcon type="clock" />
+      <EuiIcon type="clock" aria-hidden={true} />
     </EuiSmallButtonEmpty>
   );
 

--- a/public/components/data_source_top_nav_menu.tsx
+++ b/public/components/data_source_top_nav_menu.tsx
@@ -26,13 +26,15 @@ export const DataSourceTopNavMenu = ({
   setActionMenu,
   dataSourceManagement,
 }: DataSourceTopNavMenuProps) => {
-  const DataSourceMenu = useMemo(() => dataSourceManagement?.ui.getDataSourceMenu(), [
-    dataSourceManagement,
-  ]);
+  const DataSourceMenu = useMemo(
+    () => dataSourceManagement?.ui.getDataSourceMenu(),
+    [dataSourceManagement]
+  );
   const { selectedDataSourceOption, setSelectedDataSourceOption } = useContext(DataSourceContext);
-  const activeOption = useMemo(() => (selectedDataSourceOption ? [selectedDataSourceOption] : []), [
-    selectedDataSourceOption,
-  ]);
+  const activeOption = useMemo(
+    () => (selectedDataSourceOption ? [selectedDataSourceOption] : []),
+    [selectedDataSourceOption]
+  );
 
   const handleDataSourcesSelected = useCallback<
     DataSourceSelectableConfig['onSelectedDataSources']

--- a/public/components/monitoring/model_connector_filter.tsx
+++ b/public/components/monitoring/model_connector_filter.tsx
@@ -9,11 +9,10 @@ import { DO_NOT_FETCH, useFetcher } from '../../hooks';
 import { APIProvider } from '../../apis/api_provider';
 import { DataSourceId } from '../../utils/data_source';
 
-interface ModelConnectorFilterProps
-  extends Omit<
-    OptionsFilterProps,
-    'name' | 'options' | 'searchPlaceholder' | 'loading' | 'value' | 'onChange'
-  > {
+interface ModelConnectorFilterProps extends Omit<
+  OptionsFilterProps,
+  'name' | 'options' | 'searchPlaceholder' | 'loading' | 'value' | 'onChange'
+> {
   allExternalConnectors?: Array<{ id: string; name: string }>;
   value: string[];
   onChange: (value: string[]) => void;

--- a/public/components/status_filter/index.tsx
+++ b/public/components/status_filter/index.tsx
@@ -41,7 +41,7 @@ export const StatusFilter = ({ onUpdateFilters, options, loading }: Props) => {
       return {
         ...item,
         label: status!.label,
-        prepend: <EuiIcon type="dot" color={status!.color} />,
+        prepend: <EuiIcon type="dot" color={status!.color} aria-hidden={true} />,
       };
     });
   }, [options]);

--- a/public/hooks/tests/use_fetcher.test.ts
+++ b/public/hooks/tests/use_fetcher.test.ts
@@ -84,7 +84,7 @@ describe('useFetcher', () => {
         resolve('bar');
       };
     });
-    const fetcher = jest.fn((id: 'foo' | 'bar') => ({ foo: fooResult, bar: barResult }[id]));
+    const fetcher = jest.fn((id: 'foo' | 'bar') => ({ foo: fooResult, bar: barResult })[id]);
     const { result, rerender } = renderHook(
       ({ id }: { id: 'foo' | 'bar' }) => useFetcher(fetcher, id),
       {

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -20,8 +20,10 @@ import {
 } from './types';
 import { PLUGIN_NAME, PLUGIN_ID } from '../common';
 
-export class MlCommonsPluginPlugin
-  implements Plugin<MlCommonsPluginPluginSetup, MlCommonsPluginPluginStart> {
+export class MlCommonsPluginPlugin implements Plugin<
+  MlCommonsPluginPluginSetup,
+  MlCommonsPluginPluginStart
+> {
   public setup(
     core: CoreSetup<AppPluginStartDependencies, AppPluginStartDependencies>,
     { dataSource, dataSourceManagement }: MlCommonsPluginPluginSetupDependencies

--- a/server/routes/__tests__/connector_router.test.ts
+++ b/server/routes/__tests__/connector_router.test.ts
@@ -21,11 +21,8 @@ const setupRouter = ({
   getClient?: (dataSourceId: string) => Promise<Pick<OpenSearchClient, 'transport'>>;
 } = {}) => {
   const mockedLogger = loggerMock.create();
-  const {
-    router,
-    dataSourceTransportMock,
-    getLatestCurrentUserTransport,
-  } = createDataSourceEnhancedRouter(mockedLogger, getClient);
+  const { router, dataSourceTransportMock, getLatestCurrentUserTransport } =
+    createDataSourceEnhancedRouter(mockedLogger, getClient);
 
   connectorRouter(router);
   return {

--- a/server/routes/__tests__/model_router.test.ts
+++ b/server/routes/__tests__/model_router.test.ts
@@ -16,11 +16,8 @@ import { ModelService } from '../../services';
 
 const setupRouter = () => {
   const mockedLogger = loggerMock.create();
-  const {
-    router,
-    dataSourceTransportMock,
-    getLatestCurrentUserTransport,
-  } = createDataSourceEnhancedRouter(mockedLogger);
+  const { router, dataSourceTransportMock, getLatestCurrentUserTransport } =
+    createDataSourceEnhancedRouter(mockedLogger);
 
   modelRouter(router);
   return {

--- a/server/routes/__tests__/profile_router.test.ts
+++ b/server/routes/__tests__/profile_router.test.ts
@@ -16,11 +16,8 @@ import { profileRouter } from '../profile_router';
 
 const setupRouter = () => {
   const mockedLogger = loggerMock.create();
-  const {
-    router,
-    dataSourceTransportMock,
-    getLatestCurrentUserTransport,
-  } = createDataSourceEnhancedRouter(mockedLogger);
+  const { router, dataSourceTransportMock, getLatestCurrentUserTransport } =
+    createDataSourceEnhancedRouter(mockedLogger);
 
   profileRouter(router);
   return {

--- a/server/routes/router.mock.ts
+++ b/server/routes/router.mock.ts
@@ -96,19 +96,19 @@ export class MockResponseToolkit implements ResponseToolkit {
   }
 }
 
-const enhanceWithContext = (((coreContext: CoreRouteHandlerContext, otherContext?: object) => (
-  fn: (...args: unknown[]) => unknown
-) => (req: OpenSearchDashboardsRequest, res: OpenSearchDashboardsResponseFactory) => {
-  return fn.call(
-    null,
-    {
-      core: coreContext,
-      ...otherContext,
-    },
-    req,
-    res
-  );
-}) as unknown) as (
+const enhanceWithContext = ((coreContext: CoreRouteHandlerContext, otherContext?: object) =>
+  (fn: (...args: unknown[]) => unknown) =>
+  (req: OpenSearchDashboardsRequest, res: OpenSearchDashboardsResponseFactory) => {
+    return fn.call(
+      null,
+      {
+        core: coreContext,
+        ...otherContext,
+      },
+      req,
+      res
+    );
+  }) as unknown as (
   otherContext?: object
 ) => ContextEnhancer<unknown, unknown, unknown, RouteMethod>;
 


### PR DESCRIPTION
## Description

Migrates ml-commons-dashboards to ESLint 10 with flat configuration:

- Adds a flat `eslint.config.js` that spreads `@elastic/eslint-config-kibana` and the EUI config, replacing the legacy `.eslintrc` setup, and removes the now-unused `.eslintignore`.
- Drops the removed `--ext .tsx --ext .ts .` flags from the lint CI workflow (`lint:es`), which ESLint 10 no longer supports.
- Applies Prettier 3 formatting across the affected source files.

## Issues Resolved

Closes #504

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. All commits are signed off (DCO).
