### PR TITLE
Migrate Jest test suite to Jest 30 + jsdom 26

### DIFF
--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -6,11 +6,14 @@
 module.exports = {
   rootDir: '../',
   setupFiles: ['<rootDir>/test/setupTests.ts'],
-  setupFilesAfterEnv: ['<rootDir>/test/setup.jest.ts'],
+  setupFilesAfterEnv: ['jest-location-mock', '<rootDir>/test/setup.jest.ts'],
   roots: ['<rootDir>'],
   moduleNameMapper: {
     '\\.(css|less|scss)$': '<rootDir>/test/mocks/styleMock.ts',
     '^ui/(.*)': '<rootDir>/../../src/legacy/ui/public/$1/',
+    // query-string v9 is pure ESM; this shim restores the default-import shape
+    // (`import qs from 'query-string'`) under Jest's CJS transform.
+    '^query-string$': '<rootDir>/test/mocks/queryStringMock.js',
   },
   testMatch: ['**/*.test.{js,mjs,ts,tsx}'],
   testPathIgnorePatterns: ['<rootDir>/target/', '<rootDir>/node_modules/', '<rootDir>/build/'],
@@ -27,5 +30,21 @@ module.exports = {
   transform: {
     '^.+\\.(js|tsx?)$': '<rootDir>/../../src/dev/jest/babel_transform.js',
   },
+  transformIgnorePatterns: [
+    // ignore all node_modules except query-string and its pure-ESM deps, which
+    // require babel transforms since ESM is not natively supported by Jest's CJS runtime.
+    '[/\\\\]node_modules(?![\\/\\\\](query-string|decode-uri-component|filter-obj|split-on-first))[/\\\\].+\\.js$',
+  ],
   testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    // Set the default URL so window.location.origin is 'http://localhost:5601' rather than
+    // 'http://localhost', avoiding the need for tests to mock window.location.origin.
+    url: 'http://localhost:5601',
+  },
+  // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  snapshotFormat: {
+    escapeString: true,
+    printBasicPrototype: true,
+  },
 };

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -42,7 +42,7 @@ module.exports = {
     url: 'http://localhost:5601',
   },
   // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
-  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/upgrading-to-jest29
   snapshotFormat: {
     escapeString: true,
     printBasicPrototype: true,

--- a/test/mocks/queryStringMock.js
+++ b/test/mocks/queryStringMock.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * query-string v9 is a pure ESM module whose index.js has only a default export:
+ *
+ *   import * as queryString from './base.js';
+ *   export default queryString;
+ *
+ * When Babel transforms this for CJS Jest, babel-plugin-add-module-exports sets
+ * `module.exports = exports.default` (the namespace from base.js). That namespace
+ * carries `__esModule: true` (set by base.js's own transform) but has no `.default`
+ * property. A consumer compiled as `interopRequireDefault(require('query-string')).default`
+ * then gets `undefined`.
+ *
+ * This shim is set as the moduleNameMapper target for 'query-string'. It loads the
+ * real package via a hardcoded node_modules path so that Jest's moduleNameMapper does
+ * not intercept the require (which would recurse into this file).
+ */
+
+// Absolute path to the parent repo's node_modules so the moduleNameMapper (which only
+// matches the bare specifier 'query-string') cannot intercept this require.
+// eslint-disable-next-line import/no-dynamic-require
+const mod = require(
+  require('path').resolve(__dirname, '../../../../node_modules/query-string/index.js')
+);
+
+// Recover the actual API regardless of which shape we receive after the Babel +
+// babel-plugin-add-module-exports pipeline.
+const api = mod && mod.__esModule && typeof mod.stringify !== 'function' ? mod.default : mod;
+
+module.exports = {
+  __esModule: true,
+  default: api,
+};


### PR DESCRIPTION
Closes #506

### Description

Migrate this plugin's Jest test suite to run under **Jest 30.4.2 + jsdom 26.1.0**, following the
core OpenSearch-Dashboards upgrade in opensearch-project/OpenSearch-Dashboards#12381. The plugin
runs its tests against the parent repo's jest binary, so it breaks once the core upgrade lands.

**Result:** full suite green — `28 suites / 169 tests / 26 snapshots passed`, exit 0.

#### Common changes (shared across the plugin-migration campaign)
- **Config (`test/jest.config.js`):** added `jest-location-mock` as the first `setupFilesAfterEnv`
  entry; added `testEnvironmentOptions: { url: 'http://localhost:5601' }` so `window.location.origin`
  matches the app default instead of jsdom's `http://localhost`; added the
  `snapshotFormat: { escapeString: true, printBasicPrototype: true }` compatibility shim (Jest 29
  flipped these defaults, which would otherwise invalidate the existing snapshots).

All 26 snapshots pass unchanged — no snapshot header bump or regeneration was needed for this
plugin, and no matcher codemod (`toThrowError`/`toBeCalled*`) was required. The `matchMedia` /
`localStorage` / `HOST` setup, `TextEncoder` polyfill, jest-dom `extend-expect` import fix, and
`jest-raw-loader` stub common changes did not apply here (this plugin's `test/setup.jest.ts` and
`test/setupTests.ts` needed no edits, and it does not use `jest-raw-loader`).

#### Plugin-specific changes
- **`query-string` v9 is pure ESM (`test/jest.config.js` + new `test/mocks/queryStringMock.js`):**
  the parent repo bumped `query-string` to 9.x, whose `index.js` has only a default export and ships
  as ESM. Under Jest's CJS transform the `interopRequireDefault(require('query-string')).default`
  interop resolves to `undefined`, breaking any test that transitively imports it. Two coordinated
  fixes:
  - Added a `moduleNameMapper` entry `'^query-string$' → '<rootDir>/test/mocks/queryStringMock.js'`.
    The new stub `require`s the real package via a hardcoded absolute `node_modules/query-string/index.js`
    path (so the mapper can't recurse into itself), unwraps the Babel +
    `babel-plugin-add-module-exports` output regardless of shape, and re-exports it as a proper
    `{ __esModule: true, default: api }`.
  - Added a `transformIgnorePatterns` allowlist so Babel still transforms `query-string` and its
    pure-ESM transitive deps (`decode-uri-component`, `filter-obj`, `split-on-first`) instead of the
    blanket `node_modules` skip.

No `package.json` change needed — the plugin inherits the parent repo's Jest 30 stack.

### Issues Resolved

Part of the Jest 30 + jsdom 26 migration campaign (core: opensearch-project/OpenSearch-Dashboards#12381).
<!-- Add: Closes #<this-plugin-issue> -->

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
