### PR TITLE
Integrate centralized resource-sharing share button for model groups

### DIFF
--- a/public/apis/model.ts
+++ b/public/apis/model.ts
@@ -13,6 +13,7 @@ export interface ModelSearchItem {
   algorithm: string;
   model_state: string;
   model_version: string;
+  model_group_id?: string;
   current_worker_node_count: number;
   planning_worker_node_count: number;
   planning_worker_nodes: string[];

--- a/public/components/monitoring/__tests__/index.test.tsx
+++ b/public/components/monitoring/__tests__/index.test.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { render, screen, waitFor, within } from '../../../../test/test_utils';
-import { Monitoring } from '../index';
+import { Monitoring, isResourceSharingAvailableForModelGroups } from '../index';
 import * as useMonitoringExports from '../use_monitoring';
 import { APIProvider } from '../../../apis/api_provider';
 import { applicationServiceMock, chromeServiceMock } from '../../../../../../src/core/public/mocks';
@@ -396,5 +396,42 @@ describe('<Monitoring />', () => {
     setup({}, true);
 
     expect(screen.queryByLabelText('total number of results')).toBe(null);
+  });
+});
+
+describe('isResourceSharingAvailableForModelGroups', () => {
+  const appWithCaps = (resourceSharing?: Record<string, unknown>) =>
+    ({ capabilities: resourceSharing ? { resourceSharing } : {} }) as any;
+
+  it('returns false when the resourceSharing capability is absent', () => {
+    expect(isResourceSharingAvailableForModelGroups(appWithCaps())).toBe(false);
+  });
+
+  it('returns false when resource sharing is disabled', () => {
+    expect(
+      isResourceSharingAvailableForModelGroups(
+        appWithCaps({ enabled: false, availableTypes: 'ml-model-group' })
+      )
+    ).toBe(false);
+  });
+
+  it('returns false when ml-model-group is not in availableTypes', () => {
+    expect(
+      isResourceSharingAvailableForModelGroups(
+        appWithCaps({ enabled: true, availableTypes: 'workflow,anomaly-detector' })
+      )
+    ).toBe(false);
+  });
+
+  it('returns false when availableTypes is missing', () => {
+    expect(isResourceSharingAvailableForModelGroups(appWithCaps({ enabled: true }))).toBe(false);
+  });
+
+  it('returns true when enabled and ml-model-group is present in availableTypes', () => {
+    expect(
+      isResourceSharingAvailableForModelGroups(
+        appWithCaps({ enabled: true, availableTypes: 'workflow,ml-model-group,forecaster' })
+      )
+    ).toBe(true);
   });
 });

--- a/public/components/monitoring/__tests__/model_deployment_table.test.tsx
+++ b/public/components/monitoring/__tests__/model_deployment_table.test.tsx
@@ -315,4 +315,61 @@ describe('<DeployedModelTable />', () => {
       })
     );
   });
+
+  describe('resource sharing Access column', () => {
+    const itemsWithGroup = [
+      {
+        id: 'model-1-id',
+        name: 'model 1 name',
+        model_group_id: 'model-group-1',
+        respondingNodesCount: 1,
+        notRespondingNodesCount: 0,
+        planningNodesCount: 1,
+        planningWorkerNodes: [],
+        source: 'Local',
+      },
+      {
+        // no model_group_id -> cell should render nothing
+        id: 'model-2-id',
+        name: 'model 2 name',
+        respondingNodesCount: 1,
+        notRespondingNodesCount: 0,
+        planningNodesCount: 1,
+        planningWorkerNodes: [],
+        source: 'Local',
+      },
+    ];
+
+    it('renders the Access column and a share-button marker only for rows with a model_group_id when resourceSharingEnabled is true', () => {
+      const {
+        result: { container },
+      } = setup({ items: itemsWithGroup, resourceSharingEnabled: true });
+
+      expect(screen.getByRole('columnheader', { name: 'Access' })).toBeInTheDocument();
+
+      const markers = container.querySelectorAll('[data-resource-share-button]');
+      expect(markers).toHaveLength(1);
+      expect(markers[0].getAttribute('data-resource-id')).toBe('model-group-1');
+      expect(markers[0].getAttribute('data-resource-type')).toBe('ml-model-group');
+      expect(markers[0].getAttribute('data-resource-share-display')).toBe('icon');
+    });
+
+    it('does not render the Access column or any marker when resourceSharingEnabled is false', () => {
+      const {
+        result: { container },
+      } = setup({ items: itemsWithGroup, resourceSharingEnabled: false });
+
+      expect(screen.queryByRole('columnheader', { name: 'Access' })).not.toBeInTheDocument();
+      expect(container.querySelector('[data-resource-share-button]')).toBeNull();
+    });
+
+    it('does not render the Access column when resourceSharingEnabled is omitted (defaults off)', () => {
+      const {
+        result: { container },
+      } = setup({ items: itemsWithGroup });
+
+      expect(screen.queryByRole('columnheader', { name: 'Access' })).not.toBeInTheDocument();
+      expect(container.querySelector('[data-resource-share-button]')).toBeNull();
+    });
+  });
 });

--- a/public/components/monitoring/index.tsx
+++ b/public/components/monitoring/index.tsx
@@ -20,8 +20,25 @@ import { PreviewPanel } from '../preview_panel';
 import { ApplicationStart, ChromeStart } from '../../../../../src/core/public';
 import { NavigationPublicPluginStart } from '../../../../../src/plugins/navigation/public';
 
-import { ModelDeploymentItem, ModelDeploymentTable } from './model_deployment_table';
+import {
+  ML_MODEL_GROUP_RESOURCE_TYPE,
+  ModelDeploymentItem,
+  ModelDeploymentTable,
+} from './model_deployment_table';
 import { useMonitoring } from './use_monitoring';
+
+/**
+ * Whether resource sharing is available for model groups, via the core
+ * capability registered by security-dashboards-plugin. False when that plugin
+ * is not installed, the feature is disabled, or the ml-model-group type is
+ * not registered — no plugin dependency involved.
+ */
+function isResourceSharingAvailableForModelGroups(application: ApplicationStart): boolean {
+  const caps = (application.capabilities as any)?.resourceSharing;
+  if (!caps?.enabled) return false;
+  const types: string = caps.availableTypes ?? '';
+  return types.split(',').includes(ML_MODEL_GROUP_RESOURCE_TYPE);
+}
 import { ModelStatusFilter } from './model_status_filter';
 import { SearchBar } from './search_bar';
 import { ModelSourceFilter } from './model_source_filter';
@@ -156,6 +173,7 @@ export const Monitoring = (props: MonitoringProps) => {
           onChange={handleTableChange}
           onViewDetail={handleViewDetail}
           onResetSearchClick={onResetSearch}
+          resourceSharingEnabled={isResourceSharingAvailableForModelGroups(application)}
         />
         {preview && (
           <PreviewPanel

--- a/public/components/monitoring/index.tsx
+++ b/public/components/monitoring/index.tsx
@@ -33,7 +33,7 @@ import { useMonitoring } from './use_monitoring';
  * is not installed, the feature is disabled, or the ml-model-group type is
  * not registered — no plugin dependency involved.
  */
-function isResourceSharingAvailableForModelGroups(application: ApplicationStart): boolean {
+export function isResourceSharingAvailableForModelGroups(application: ApplicationStart): boolean {
   const caps = (application.capabilities as any)?.resourceSharing;
   if (!caps?.enabled) return false;
   const types: string = caps.availableTypes ?? '';

--- a/public/components/monitoring/model_deployment_table.tsx
+++ b/public/components/monitoring/model_deployment_table.tsx
@@ -188,7 +188,7 @@ export const ModelDeploymentTable = ({
               // button (for the model's model group) is mounted here by
               // security-dashboards-plugin when installed and enabled.
               field: 'model_group_id',
-              name: 'Share',
+              name: 'Access',
               width: '5%',
               render: (modelGroupId: string | undefined) =>
                 modelGroupId ? (

--- a/public/components/monitoring/model_deployment_table.tsx
+++ b/public/components/monitoring/model_deployment_table.tsx
@@ -23,6 +23,12 @@ import {
 
 import { MODEL_STATE } from '../../../common';
 
+/**
+ * Resource type registered by the ml-commons backend plugin with the security
+ * plugin's resource-sharing framework. Sharing is model-group scoped.
+ */
+export const ML_MODEL_GROUP_RESOURCE_TYPE = 'ml-model-group';
+
 export interface ModelDeploymentTableSort {
   field: 'name' | 'model_state' | 'id';
   direction: Direction;
@@ -37,6 +43,7 @@ export interface ModelDeploymentItem {
   id: string;
   name: string;
   model_state?: MODEL_STATE;
+  model_group_id?: string;
   respondingNodesCount: number | undefined;
   planningNodesCount: number | undefined;
   notRespondingNodesCount: number | undefined;
@@ -61,6 +68,11 @@ export interface ModelDeploymentTableProps {
   onChange: (criteria: ModelDeploymentTableCriteria) => void;
   onViewDetail?: (modelDeploymentItem: ModelDeploymentItem) => void;
   onResetSearchClick?: () => void;
+  /**
+   * When true, renders a Share column with resource-sharing SPI markers that
+   * security-dashboards-plugin fulfills with its centralized share button.
+   */
+  resourceSharingEnabled?: boolean;
 }
 
 export const ModelDeploymentTable = ({
@@ -72,6 +84,7 @@ export const ModelDeploymentTable = ({
   onChange,
   onViewDetail,
   onResetSearchClick,
+  resourceSharingEnabled,
 }: ModelDeploymentTableProps) => {
   const columns = useMemo(
     () => [
@@ -168,6 +181,27 @@ export const ModelDeploymentTable = ({
           </>
         ),
       },
+      ...(resourceSharingEnabled
+        ? [
+            {
+              // Resource-sharing SPI marker column: the centralized Share
+              // button (for the model's model group) is mounted here by
+              // security-dashboards-plugin when installed and enabled.
+              field: 'model_group_id',
+              name: 'Share',
+              width: '5%',
+              render: (modelGroupId: string | undefined) =>
+                modelGroupId ? (
+                  <div
+                    data-resource-share-button
+                    data-resource-id={modelGroupId}
+                    data-resource-type={ML_MODEL_GROUP_RESOURCE_TYPE}
+                    data-resource-share-display="icon"
+                  />
+                ) : null,
+            },
+          ]
+        : []),
       {
         field: 'id',
         name: 'Action',
@@ -189,7 +223,7 @@ export const ModelDeploymentTable = ({
         },
       },
     ],
-    [onViewDetail]
+    [onViewDetail, resourceSharingEnabled]
   );
   const sorting = useMemo(() => ({ sort }), [sort]);
 

--- a/public/components/monitoring/use_monitoring.ts
+++ b/public/components/monitoring/use_monitoring.ts
@@ -157,6 +157,7 @@ const fetchDeployedModels = async (
         return {
           id,
           name,
+          model_group_id: rest.model_group_id,
           respondingNodesCount: workerCount,
           planningNodesCount: planningCount,
           notRespondingNodesCount:


### PR DESCRIPTION
### Description
Integrates the centralized share button from [security-dashboards-plugin PR #2491](https://github.com/opensearch-project/security-dashboards-plugin/pull/2491) via its dependency-free DOM-marker SPI.

**How it works**
- Renders empty marker elements (`data-resource-share-button` + resource id/type attributes); the security plugin mounts its Share/Update Access button + modal into them when installed and resource sharing is enabled
- UI chrome (Share column) is gated on the core `resourceSharing` capability (`enabled` + type present in `availableTypes`), so it is completely absent when the feature is off or the security plugin is missing
- No dependency on the security plugin: no manifest changes, no imports from it — markers are inert empty elements when unfulfilled

**Testing**: verified manually on OpenSearch 3.8.0 (staging) + OSD main with resource sharing enabled — share/update flows, `can_share: false` graying, and feature-off column hiding.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
