### PR TITLE
Gate resource-sharing Access column on per-data-source availability

### DIFF
--- a/public/components/monitoring/__tests__/index.test.tsx
+++ b/public/components/monitoring/__tests__/index.test.tsx
@@ -406,8 +406,8 @@ describe('<Monitoring />', () => {
 
     const mockResourceSharingResponses = (enabled: boolean, types: string[]) => {
       const get = jest.fn(async (path: string) => {
-        if (path === '/api/v1/auth/dashboardsinfo') {
-          return { resource_sharing_enabled: enabled };
+        if (path === '/api/v1/auth/resource_sharing_enabled') {
+          return { enabled };
         }
         return { types: types.map((type) => ({ type })) };
       });
@@ -452,8 +452,8 @@ describe('getResourceSharingAvailableTypes', () => {
 
   it('returns an empty list when resource sharing is disabled on the data source', async () => {
     mockHttpGet(async (path) => {
-      if (path === '/api/v1/auth/dashboardsinfo') {
-        return { resource_sharing_enabled: false };
+      if (path === '/api/v1/auth/resource_sharing_enabled') {
+        return { enabled: false };
       }
       return { types: [{ type: 'ml-model-group' }] };
     });
@@ -462,8 +462,8 @@ describe('getResourceSharingAvailableTypes', () => {
 
   it('returns the registered types when resource sharing is enabled', async () => {
     mockHttpGet(async (path) => {
-      if (path === '/api/v1/auth/dashboardsinfo') {
-        return { resource_sharing_enabled: true };
+      if (path === '/api/v1/auth/resource_sharing_enabled') {
+        return { enabled: true };
       }
       return { types: [{ type: 'ml-model-group' }, { type: 'workflow' }, {}] };
     });
@@ -472,8 +472,8 @@ describe('getResourceSharingAvailableTypes', () => {
 
   it('supports a bare array response from the types endpoint', async () => {
     mockHttpGet(async (path) => {
-      if (path === '/api/v1/auth/dashboardsinfo') {
-        return { resource_sharing_enabled: true };
+      if (path === '/api/v1/auth/resource_sharing_enabled') {
+        return { enabled: true };
       }
       return [{ type: 'ml-model-group' }];
     });
@@ -482,13 +482,13 @@ describe('getResourceSharingAvailableTypes', () => {
 
   it('passes the data source id as a query parameter to both endpoints', async () => {
     const get = mockHttpGet(async (path) => {
-      if (path === '/api/v1/auth/dashboardsinfo') {
-        return { resource_sharing_enabled: true };
+      if (path === '/api/v1/auth/resource_sharing_enabled') {
+        return { enabled: true };
       }
       return { types: [{ type: 'ml-model-group' }] };
     });
     await getResourceSharingAvailableTypes('data-source-1');
-    expect(get).toHaveBeenCalledWith('/api/v1/auth/dashboardsinfo', {
+    expect(get).toHaveBeenCalledWith('/api/v1/auth/resource_sharing_enabled', {
       query: { dataSourceId: 'data-source-1' },
     });
     expect(get).toHaveBeenCalledWith('/api/resource/types', {
@@ -497,9 +497,9 @@ describe('getResourceSharingAvailableTypes', () => {
   });
 
   it('omits the data source id from the query when not provided', async () => {
-    const get = mockHttpGet(async () => ({ resource_sharing_enabled: false }));
+    const get = mockHttpGet(async () => ({ enabled: false }));
     await getResourceSharingAvailableTypes();
-    expect(get).toHaveBeenCalledWith('/api/v1/auth/dashboardsinfo', { query: {} });
+    expect(get).toHaveBeenCalledWith('/api/v1/auth/resource_sharing_enabled', { query: {} });
   });
 
   it('returns an empty list when the probe fails', async () => {

--- a/public/components/monitoring/__tests__/index.test.tsx
+++ b/public/components/monitoring/__tests__/index.test.tsx
@@ -7,9 +7,10 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { render, screen, waitFor, within } from '../../../../test/test_utils';
-import { Monitoring, isResourceSharingAvailableForModelGroups } from '../index';
+import { Monitoring, getResourceSharingAvailableTypes } from '../index';
 import * as useMonitoringExports from '../use_monitoring';
 import { APIProvider } from '../../../apis/api_provider';
+import { InnerHttpProvider } from '../../../apis/inner_http_provider';
 import { applicationServiceMock, chromeServiceMock } from '../../../../../../src/core/public/mocks';
 import { navigationPluginMock } from '../../../../../../src/plugins/navigation/public/mocks';
 
@@ -397,41 +398,114 @@ describe('<Monitoring />', () => {
 
     expect(screen.queryByLabelText('total number of results')).toBe(null);
   });
+
+  describe('resource sharing Access column gating', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    const mockResourceSharingResponses = (enabled: boolean, types: string[]) => {
+      const get = jest.fn(async (path: string) => {
+        if (path === '/api/v1/auth/dashboardsinfo') {
+          return { resource_sharing_enabled: enabled };
+        }
+        return { types: types.map((type) => ({ type })) };
+      });
+      jest.spyOn(InnerHttpProvider, 'getHttp').mockReturnValue({ get } as any);
+      return get;
+    };
+
+    it('should render the Access column when the selected data source supports ml-model-group sharing', async () => {
+      mockResourceSharingResponses(true, ['ml-model-group']);
+      setup();
+      await waitFor(() =>
+        expect(screen.getByRole('columnheader', { name: 'Access' })).toBeInTheDocument()
+      );
+    });
+
+    it('should NOT render the Access column when resource sharing is disabled on the data source', async () => {
+      const get = mockResourceSharingResponses(false, ['ml-model-group']);
+      setup();
+      await waitFor(() => expect(get).toHaveBeenCalled());
+      expect(screen.queryByRole('columnheader', { name: 'Access' })).not.toBeInTheDocument();
+    });
+
+    it('should NOT render the Access column when ml-model-group is not a shareable type', async () => {
+      const get = mockResourceSharingResponses(true, ['workflow']);
+      setup();
+      await waitFor(() => expect(get).toHaveBeenCalledWith('/api/resource/types', { query: {} }));
+      expect(screen.queryByRole('columnheader', { name: 'Access' })).not.toBeInTheDocument();
+    });
+  });
 });
 
-describe('isResourceSharingAvailableForModelGroups', () => {
-  const appWithCaps = (resourceSharing?: Record<string, unknown>) =>
-    ({ capabilities: resourceSharing ? { resourceSharing } : {} }) as any;
+describe('getResourceSharingAvailableTypes', () => {
+  const mockHttpGet = (implementation: (path: string, options?: any) => Promise<any>) => {
+    const get = jest.fn(implementation);
+    jest.spyOn(InnerHttpProvider, 'getHttp').mockReturnValue({ get } as any);
+    return get;
+  };
 
-  it('returns false when the resourceSharing capability is absent', () => {
-    expect(isResourceSharingAvailableForModelGroups(appWithCaps())).toBe(false);
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
-  it('returns false when resource sharing is disabled', () => {
-    expect(
-      isResourceSharingAvailableForModelGroups(
-        appWithCaps({ enabled: false, availableTypes: 'ml-model-group' })
-      )
-    ).toBe(false);
+  it('returns an empty list when resource sharing is disabled on the data source', async () => {
+    mockHttpGet(async (path) => {
+      if (path === '/api/v1/auth/dashboardsinfo') {
+        return { resource_sharing_enabled: false };
+      }
+      return { types: [{ type: 'ml-model-group' }] };
+    });
+    expect(await getResourceSharingAvailableTypes()).toEqual([]);
   });
 
-  it('returns false when ml-model-group is not in availableTypes', () => {
-    expect(
-      isResourceSharingAvailableForModelGroups(
-        appWithCaps({ enabled: true, availableTypes: 'workflow,anomaly-detector' })
-      )
-    ).toBe(false);
+  it('returns the registered types when resource sharing is enabled', async () => {
+    mockHttpGet(async (path) => {
+      if (path === '/api/v1/auth/dashboardsinfo') {
+        return { resource_sharing_enabled: true };
+      }
+      return { types: [{ type: 'ml-model-group' }, { type: 'workflow' }, {}] };
+    });
+    expect(await getResourceSharingAvailableTypes()).toEqual(['ml-model-group', 'workflow']);
   });
 
-  it('returns false when availableTypes is missing', () => {
-    expect(isResourceSharingAvailableForModelGroups(appWithCaps({ enabled: true }))).toBe(false);
+  it('supports a bare array response from the types endpoint', async () => {
+    mockHttpGet(async (path) => {
+      if (path === '/api/v1/auth/dashboardsinfo') {
+        return { resource_sharing_enabled: true };
+      }
+      return [{ type: 'ml-model-group' }];
+    });
+    expect(await getResourceSharingAvailableTypes()).toEqual(['ml-model-group']);
   });
 
-  it('returns true when enabled and ml-model-group is present in availableTypes', () => {
-    expect(
-      isResourceSharingAvailableForModelGroups(
-        appWithCaps({ enabled: true, availableTypes: 'workflow,ml-model-group,forecaster' })
-      )
-    ).toBe(true);
+  it('passes the data source id as a query parameter to both endpoints', async () => {
+    const get = mockHttpGet(async (path) => {
+      if (path === '/api/v1/auth/dashboardsinfo') {
+        return { resource_sharing_enabled: true };
+      }
+      return { types: [{ type: 'ml-model-group' }] };
+    });
+    await getResourceSharingAvailableTypes('data-source-1');
+    expect(get).toHaveBeenCalledWith('/api/v1/auth/dashboardsinfo', {
+      query: { dataSourceId: 'data-source-1' },
+    });
+    expect(get).toHaveBeenCalledWith('/api/resource/types', {
+      query: { dataSourceId: 'data-source-1' },
+    });
+  });
+
+  it('omits the data source id from the query when not provided', async () => {
+    const get = mockHttpGet(async () => ({ resource_sharing_enabled: false }));
+    await getResourceSharingAvailableTypes();
+    expect(get).toHaveBeenCalledWith('/api/v1/auth/dashboardsinfo', { query: {} });
+  });
+
+  it('returns an empty list when the probe fails', async () => {
+    mockHttpGet(async () => {
+      throw new Error('network error');
+    });
+    expect(await getResourceSharingAvailableTypes()).toEqual([]);
   });
 });

--- a/public/components/monitoring/index.tsx
+++ b/public/components/monitoring/index.tsx
@@ -39,8 +39,8 @@ export const getResourceSharingAvailableTypes = async (
     const http = InnerHttpProvider.getHttp();
     const query = resourceDataSourceId ? { dataSourceId: resourceDataSourceId } : {};
     // Global gate: resource sharing must be enabled on the selected data source.
-    const info: any = await http.get('/api/v1/auth/dashboardsinfo', { query });
-    if (!info?.resource_sharing_enabled) {
+    const info: any = await http.get('/api/v1/auth/resource_sharing_enabled', { query });
+    if (!info?.enabled) {
       return [];
     }
     // Per-type gate: the registered/protected shareable types on that source.

--- a/public/components/monitoring/index.tsx
+++ b/public/components/monitoring/index.tsx
@@ -12,13 +12,14 @@ import {
   EuiText,
   EuiFilterGroup,
 } from '@elastic/eui';
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
 
 import { ModelDeploymentProfile } from '../../apis/profile';
 import { PreviewPanel } from '../preview_panel';
 import { ApplicationStart, ChromeStart } from '../../../../../src/core/public';
 import { NavigationPublicPluginStart } from '../../../../../src/plugins/navigation/public';
+import { InnerHttpProvider } from '../../apis/inner_http_provider';
 
 import {
   ML_MODEL_GROUP_RESOURCE_TYPE,
@@ -28,17 +29,32 @@ import {
 import { useMonitoring } from './use_monitoring';
 
 /**
- * Whether resource sharing is available for model groups, via the core
- * capability registered by security-dashboards-plugin. False when that plugin
- * is not installed, the feature is disabled, or the ml-model-group type is
- * not registered — no plugin dependency involved.
+ * Resolve the shareable resource types available on the given data source by
+ * probing the security plugin's data-source-aware endpoints. Returns an empty
+ * list when the security plugin is not installed, resource sharing is
+ * disabled on that data source, or the probe fails.
  */
-export function isResourceSharingAvailableForModelGroups(application: ApplicationStart): boolean {
-  const caps = (application.capabilities as any)?.resourceSharing;
-  if (!caps?.enabled) return false;
-  const types: string = caps.availableTypes ?? '';
-  return types.split(',').includes(ML_MODEL_GROUP_RESOURCE_TYPE);
-}
+export const getResourceSharingAvailableTypes = async (
+  resourceDataSourceId?: string
+): Promise<string[]> => {
+  try {
+    const http = InnerHttpProvider.getHttp();
+    const query = resourceDataSourceId ? { dataSourceId: resourceDataSourceId } : {};
+    // Global gate: resource sharing must be enabled on the selected data source.
+    const info: any = await http.get('/api/v1/auth/dashboardsinfo', { query });
+    if (!info?.resource_sharing_enabled) {
+      return [];
+    }
+    // Per-type gate: the registered/protected shareable types on that source.
+    const typesResp: any = await http.get('/api/resource/types', { query });
+    const rawTypes = Array.isArray(typesResp) ? typesResp : (typesResp?.types ?? []);
+    return rawTypes
+      .map((entry: { type: string }) => entry?.type)
+      .filter((type: string | undefined): type is string => Boolean(type));
+  } catch (e) {
+    return [];
+  }
+};
 import { ModelStatusFilter } from './model_status_filter';
 import { SearchBar } from './search_bar';
 import { ModelSourceFilter } from './model_source_filter';
@@ -72,7 +88,28 @@ export const Monitoring = (props: MonitoringProps) => {
     model: ModelDeploymentItem;
     dataSourceId: string | undefined;
   } | null>(null);
+  const [resourceSharingAvailableTypes, setResourceSharingAvailableTypes] = useState<string[]>([]);
   const searchInputRef = useRef<HTMLInputElement | null>();
+
+  // Probe the shareable resource types on mount and whenever the selected
+  // data source changes, so the Access column reflects the selected source.
+  useEffect(() => {
+    // Skip while the data source id is still being resolved or is invalid.
+    if (typeof params.dataSourceId === 'symbol') {
+      return;
+    }
+    let ignore = false;
+    getResourceSharingAvailableTypes(params.dataSourceId).then((types) => {
+      if (!ignore) {
+        setResourceSharingAvailableTypes((previousTypes) =>
+          previousTypes.length === 0 && types.length === 0 ? previousTypes : types
+        );
+      }
+    });
+    return () => {
+      ignore = true;
+    };
+  }, [params.dataSourceId]);
 
   const setInputRef = useCallback((node: HTMLInputElement | null) => {
     searchInputRef.current = node;
@@ -173,7 +210,9 @@ export const Monitoring = (props: MonitoringProps) => {
           onChange={handleTableChange}
           onViewDetail={handleViewDetail}
           onResetSearchClick={onResetSearch}
-          resourceSharingEnabled={isResourceSharingAvailableForModelGroups(application)}
+          resourceSharingEnabled={resourceSharingAvailableTypes.includes(
+            ML_MODEL_GROUP_RESOURCE_TYPE
+          )}
         />
         {preview && (
           <PreviewPanel

--- a/public/components/monitoring/index.tsx
+++ b/public/components/monitoring/index.tsx
@@ -29,10 +29,8 @@ import {
 import { useMonitoring } from './use_monitoring';
 
 /**
- * Resolve the shareable resource types available on the given data source by
- * probing the security plugin's data-source-aware endpoints. Returns an empty
- * list when the security plugin is not installed, resource sharing is
- * disabled on that data source, or the probe fails.
+ * Resource-sharing types available on the given data source (feature flag +
+ * per-type list). Returns [] when disabled or on error.
  */
 export const getResourceSharingAvailableTypes = async (
   resourceDataSourceId?: string


### PR DESCRIPTION
### Description
Fast-follow to #512 (centralized resource-sharing share button). Gates the Access column on **per-data-source** resource-sharing availability instead of the local, synchronous Dashboards capability: it now checks BOTH the global `resource_sharing_enabled` feature flag and per-type membership, evaluated per selected data source, so the column correctly hides on data sources where resource sharing is disabled.

Depends on the security-dashboards-plugin data-source-aware `dashboardsinfo` route (opensearch-project/security-dashboards-plugin#2520).

### Testing
- Updated unit tests.
- Verified E2E on a multi-data-source setup (enabled vs disabled data source).
